### PR TITLE
Represent cloud points and element "spheres" using std::array

### DIFF
--- a/src/cli/align_monte/mol_aligner.cpp
+++ b/src/cli/align_monte/mol_aligner.cpp
@@ -17,11 +17,11 @@ using namespace std;
 namespace mesaac::align_monte {
 namespace {
 // TODO extract to a shared header.
-static constexpr float c_flip_matrix[4][3] = {{1.0, 1.0, 1.0}, // Unflipped
-                                              {1.0, -1.0, -1.0},
-                                              {-1.0, 1.0, -1.0},
-                                              {-1.0, -1.0, 1.0}};
-static constexpr unsigned int c_flip_matrix_size =
+constexpr float c_flip_matrix[4][3] = {{1.0, 1.0, 1.0}, // Unflipped
+                                       {1.0, -1.0, -1.0},
+                                       {-1.0, 1.0, -1.0},
+                                       {-1.0, -1.0, 1.0}};
+constexpr unsigned int c_flip_matrix_size =
     sizeof(c_flip_matrix) / sizeof(c_flip_matrix[0]);
 
 void add_tag(mol::Mol &mol, string tag, string value) {
@@ -44,7 +44,6 @@ void add_best_flip_tag(mol::Mol &mol, string measure_name, unsigned int value) {
 
 void get_flipped_points(const shape::SphereList &points, const float *flip,
                         shape::SphereList &flipped_points) {
-  // How to obviate this copying?  It eats 10% of runtime.
   flipped_points = points;
   for (auto &p : flipped_points) {
     p[0] *= flip[0];
@@ -102,12 +101,12 @@ void MolAligner::compute_best_sphere_fingerprint(
     unsigned int &i_best, float &best_measure) {
   i_best = 0;
   best_measure = 0;
-  for (unsigned int iFlip = 0; iFlip != c_flip_matrix_size; iFlip++) {
-    const float *flip = c_flip_matrix[iFlip];
-    float currMeasure = compute_measure_for_flip(points, flip, measure);
-    if (currMeasure > best_measure) {
-      i_best = iFlip;
-      best_measure = currMeasure;
+  for (unsigned int i_flip = 0; i_flip != c_flip_matrix_size; i_flip++) {
+    const float *flip = c_flip_matrix[i_flip];
+    const float curr_measure = compute_measure_for_flip(points, flip, measure);
+    if (curr_measure > best_measure) {
+      i_best = i_flip;
+      best_measure = curr_measure;
     }
   }
 }

--- a/src/cli/align_monte/mol_aligner.hpp
+++ b/src/cli/align_monte/mol_aligner.hpp
@@ -16,7 +16,7 @@
 namespace mesaac::align_monte {
 class MolAligner {
 public:
-  MolAligner(PointList &hamms_sphere_coords, float epsilon_sqr,
+  MolAligner(shape::Point3DList &hamms_sphere_coords, float epsilon_sqr,
              shape_defs::BitVector &ref_fp, bool atom_centers_only,
              MeasuresList &measures)
       : m_ref_fingerprint(ref_fp),
@@ -32,11 +32,12 @@ protected:
   shape::VolBox m_volBox;
   MeasuresList &m_measures;
 
-  void compute_best_sphere_fingerprint(const PointList &points,
+  void compute_best_sphere_fingerprint(const shape::SphereList &points,
                                        measures::MeasuresBase::Ptr measure,
                                        unsigned int &i_best,
                                        float &best_measure);
-  float compute_measure_for_flip(const PointList &points, const float *flip,
+  float compute_measure_for_flip(const shape::SphereList &points,
+                                 const float *flip,
                                  measures::MeasuresBase::Ptr measure);
   void flip_mol(mol::Mol &mol, const float *flip);
 

--- a/src/cli/align_monte/sdf_mol_aligner.cpp
+++ b/src/cli/align_monte/sdf_mol_aligner.cpp
@@ -75,11 +75,9 @@ void SDFMolAligner::read_sphere_points() {
   ifstream inf;
   open_input(inf, m_hamms_sphere_pathname, "Hamms Sphere Points file");
 
-  float coord;
-  while (inf >> coord) {
-    shape::Point3D point{coord, 0, 0};
-    inf >> point[1] >> point[2];
-    m_hamms_sphere_coords.push_back(point);
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    m_hamms_sphere_coords.emplace_back(shape::Point3D{x, y, z});
   }
   inf.close();
 }

--- a/src/cli/align_monte/sdf_mol_aligner.cpp
+++ b/src/cli/align_monte/sdf_mol_aligner.cpp
@@ -77,8 +77,7 @@ void SDFMolAligner::read_sphere_points() {
 
   float coord;
   while (inf >> coord) {
-    FloatVector point(3, 0.0);
-    point[0] = coord;
+    shape::Point3D point{coord, 0, 0};
     inf >> point[1] >> point[2];
     m_hamms_sphere_coords.push_back(point);
   }

--- a/src/cli/align_monte/sdf_mol_aligner.hpp
+++ b/src/cli/align_monte/sdf_mol_aligner.hpp
@@ -36,7 +36,7 @@ protected:
   MeasuresList &m_measures;
   std::string m_sorted_pathname;
 
-  PointList m_hamms_sphere_coords;
+  shape::Point3DList m_hamms_sphere_coords;
   shape_defs::BitVector m_ref_fingerprint;
 
   void read_sphere_points();

--- a/src/cli/align_monte/shared_types.hpp
+++ b/src/cli/align_monte/shared_types.hpp
@@ -9,9 +9,6 @@
 #include "mesaac_shape/shared_types.hpp"
 
 namespace mesaac::align_monte {
-typedef shape::Point FloatVector;
-typedef shape::PointList PointList;
-typedef std::vector<PointList> ConformerPointsList;
-
-typedef std::vector<measures::MeasuresBase::Ptr> MeasuresList;
+using ConformerPointsList = std::vector<shape::Point3DList>;
+using MeasuresList = std::vector<measures::MeasuresBase::Ptr>;
 } // namespace mesaac::align_monte

--- a/src/cli/shape_fingerprinter/mol_fingerprinter.cpp
+++ b/src/cli/shape_fingerprinter/mol_fingerprinter.cpp
@@ -20,8 +20,8 @@ const static unsigned int c_flip_matrix_size =
 
 } // namespace
 
-MolFingerprinter::MolFingerprinter(shape::PointList &hammsEllipsoidCoords,
-                                   shape::PointList &hammsSphereCoords,
+MolFingerprinter::MolFingerprinter(shape::Point3DList &hammsEllipsoidCoords,
+                                   shape::Point3DList &hammsSphereCoords,
                                    float epsilonSqr, unsigned int numFolds)
     : m_axis_aligner(hammsSphereCoords, epsilonSqr, true),
       m_volbox(hammsEllipsoidCoords, epsilonSqr), m_num_folds(numFolds),
@@ -47,15 +47,12 @@ bool MolFingerprinter::get_next_fp(shape_defs::BitVector &fp) {
 }
 
 namespace {
-inline void get_flipped_points(const shape::PointList &points,
+inline void get_flipped_points(const shape::SphereList &points,
                                const float *flip,
-                               shape::PointList &flippedPoints) {
-  flippedPoints = points;
+                               shape::SphereList &flipped_points) {
+  flipped_points = points;
 
-  shape::PointList::iterator iEnd(flippedPoints.end());
-  shape::PointList::iterator i;
-  for (i = flippedPoints.begin(); i != iEnd; ++i) {
-    shape::Point &p(*i);
+  for (auto &p : flipped_points) {
     p[0] *= flip[0];
     p[1] *= flip[1];
     p[2] *= flip[2];
@@ -65,13 +62,13 @@ inline void get_flipped_points(const shape::PointList &points,
 } // namespace
 
 void MolFingerprinter::compute_curr_flip_fingerprint(
-    const shape::PointList &points, shape_defs::BitVector &result) {
+    const shape::SphereList &points, shape_defs::BitVector &result) {
   const float *flip = c_flip_matrix[m_i_flip];
-  shape::PointList flippedPoints;
-  get_flipped_points(points, flip, flippedPoints);
+  shape::SphereList flipped_points;
+  get_flipped_points(points, flip, flipped_points);
 
   result.resize(m_volbox.size() / (1 << m_num_folds));
   result.reset();
-  m_volbox.set_folded_bits_for_spheres(flippedPoints, result, m_num_folds, 0);
+  m_volbox.set_folded_bits_for_spheres(flipped_points, result, m_num_folds, 0);
 }
 } // namespace mesaac::shape_fingerprinter

--- a/src/cli/shape_fingerprinter/mol_fingerprinter.hpp
+++ b/src/cli/shape_fingerprinter/mol_fingerprinter.hpp
@@ -14,8 +14,8 @@
 namespace mesaac::shape_fingerprinter {
 class MolFingerprinter {
 public:
-  MolFingerprinter(shape::PointList &hamms_ellipsoid_coords,
-                   shape::PointList &hamms_sphere_coords, float epsilon_sqr,
+  MolFingerprinter(shape::Point3DList &hamms_ellipsoid_coords,
+                   shape::Point3DList &hamms_sphere_coords, float epsilon_sqr,
                    unsigned int numFolds);
 
   /// @brief Set the molecule for which to compute fingerprints.
@@ -38,9 +38,9 @@ protected:
 
   mol::Mol m_mol;
   unsigned int m_i_flip;
-  shape::PointList m_heavies;
+  shape::SphereList m_heavies;
 
-  void compute_curr_flip_fingerprint(const shape::PointList &points,
+  void compute_curr_flip_fingerprint(const shape::SphereList &points,
                                      shape_defs::BitVector &result);
 };
 } // namespace mesaac::shape_fingerprinter

--- a/src/cli/shape_fingerprinter/sdf_shape_fingerprinter.cpp
+++ b/src/cli/shape_fingerprinter/sdf_shape_fingerprinter.cpp
@@ -27,11 +27,9 @@ void read_points(string &pathname, string description,
     exit(1);
   }
 
-  float coord;
-  while (inf >> coord) {
-    shape::Point3D p{coord, 0, 0};
-    inf >> p[1] >> p[2];
-    points.push_back(p);
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    points.emplace_back(shape::Point3D{x, y, z});
   }
   inf.close();
 }

--- a/src/cli/shape_fingerprinter/sdf_shape_fingerprinter.cpp
+++ b/src/cli/shape_fingerprinter/sdf_shape_fingerprinter.cpp
@@ -18,7 +18,8 @@ using namespace std;
 
 namespace mesaac::shape_fingerprinter {
 namespace {
-void read_points(string &pathname, string description, PointList &points) {
+void read_points(string &pathname, string description,
+                 shape::Point3DList &points) {
   ifstream inf(pathname);
   if (!inf) {
     cerr << "Cannot open " << description << " '" << pathname
@@ -28,8 +29,7 @@ void read_points(string &pathname, string description, PointList &points) {
 
   float coord;
   while (inf >> coord) {
-    FloatVector p(3, 0.0);
-    p[0] = coord;
+    shape::Point3D p{coord, 0, 0};
     inf >> p[1] >> p[2];
     points.push_back(p);
   }
@@ -70,15 +70,15 @@ SDFShapeFingerprinter::SDFShapeFingerprinter(
       m_format(format), m_num_folds(num_folds) {}
 
 void SDFShapeFingerprinter::run(int start_index, int end_index) {
-  PointList ellipsoid, sphere;
+  shape::Point3DList ellipsoid, sphere;
   read_points(m_hamms_ellipsoid_pathname, "hamms_ellipsoid_filename",
               ellipsoid);
   read_points(m_hamms_sphere_pathname, "hamms_sphere_filename", sphere);
   process_molecules(ellipsoid, sphere, start_index, end_index);
 }
 
-void SDFShapeFingerprinter::process_molecules(PointList &ellipsoid,
-                                              PointList &sphere,
+void SDFShapeFingerprinter::process_molecules(shape::Point3DList &ellipsoid,
+                                              shape::Point3DList &sphere,
                                               int start_index, int end_index) {
   if (start_index < 0) {
     cerr << "Invalid start index " << start_index << " -- must be >= 0" << endl;

--- a/src/cli/shape_fingerprinter/sdf_shape_fingerprinter.hpp
+++ b/src/cli/shape_fingerprinter/sdf_shape_fingerprinter.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "shared_types.hpp"
+#include "mesaac_shape/shared_types.hpp"
 
 namespace mesaac::shape_fingerprinter {
 class SDFShapeFingerprinter {
@@ -37,8 +37,9 @@ protected:
   FormatEnum m_format;
   unsigned int m_num_folds;
 
-  void process_molecules(PointList &ellipsoid, PointList &sphere,
-                         int start_index, int end_index);
+  void process_molecules(shape::Point3DList &ellipsoid,
+                         shape::Point3DList &sphere, int start_index,
+                         int end_index);
 
 private:
   SDFShapeFingerprinter(const SDFShapeFingerprinter &src);

--- a/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner.hpp
@@ -7,8 +7,9 @@
 #include "mesaac_mol/mol.hpp"
 #include "mesaac_shape/shared_types.hpp"
 #include "mesaac_shape/vol_box.hpp"
-// Singular value decomposition, for PCA -- this defines ap::real_2d_array
-#include "svd.h"
+// Singular value decomposition, for PCA -- this, from dependencies/svd/libs,
+// defines ap::real_2d_array
+#include "ap.h"
 
 /**
  * @brief Namespace for shape computations using alglib svd.

--- a/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner.hpp
@@ -14,17 +14,17 @@
  * @brief Namespace for shape computations using alglib svd.
  */
 namespace mesaac::shape {
-typedef ap::real_2d_array Transform;
+using Transform = ap::real_2d_array;
 
 class AxisAligner {
 public:
-  AxisAligner(const PointList &sphere, float atom_scale,
+  AxisAligner(const Point3DList &points, float atom_scale,
               bool atom_centers_only);
 
   void align_to_axes(mesaac::mol::Mol &m);
   void align_to_axes(mesaac::mol::AtomVector &atoms);
-  void get_atom_points(const mesaac::mol::AtomVector &atoms, PointList &centers,
-                       bool include_hydrogens);
+  void get_atom_points(const mesaac::mol::AtomVector &atoms,
+                       SphereList &centers, bool include_hydrogens);
 
 protected:
   VolBox m_volbox;
@@ -33,14 +33,15 @@ protected:
 
   // These really should not be exposed as member functions.
   // They are so exposed to ease unit testing.
-  void mean_center_points(PointList &centers);
-  void get_mean_centered_cloud(const PointList &centers, PointList &cloud);
-  void find_axis_align_transform(const PointList &cloud, Transform &transform);
+  void mean_center_points(SphereList &centers);
+  void get_mean_centered_cloud(const SphereList &centers, Point3DList &cloud);
+  void find_axis_align_transform(const Point3DList &cloud,
+                                 Transform &transform);
 
-  void get_mean_center(const PointList &centers, Point &mean);
-  void untranslate_points(PointList &all_centers, const Point &offset);
-  void transform_points(PointList &all_centers, Transform &transform);
+  void get_mean_center(const SphereList &centers, Point3D &mean);
+  void untranslate_points(SphereList &all_centers, const Point3D &offset);
+  void transform_points(SphereList &all_centers, Transform &transform);
   void update_atom_coords(mesaac::mol::AtomVector &atoms,
-                          const PointList &all_centers);
+                          const SphereList &all_centers);
 };
 } // namespace mesaac::shape

--- a/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner_eigen.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner_eigen.hpp
@@ -18,15 +18,15 @@ typedef Eigen::Matrix3f Transform;
 
 class AxisAlignerEigen {
 public:
-  AxisAlignerEigen(const PointList &sphere, float atom_scale,
+  AxisAlignerEigen(const Point3DList &points, float atom_scale,
                    bool atom_centers_only)
-      : m_volbox(sphere, atom_scale), m_atom_scale(atom_scale),
+      : m_volbox(points, atom_scale), m_atom_scale(atom_scale),
         m_atom_centers_only(atom_centers_only) {}
 
   void align_to_axes(mesaac::mol::Mol &m);
   void align_to_axes(mesaac::mol::AtomVector &atoms);
-  void get_atom_points(const mesaac::mol::AtomVector &atoms, PointList &centers,
-                       bool include_hydrogens);
+  void get_atom_points(const mesaac::mol::AtomVector &atoms,
+                       SphereList &centers, bool include_hydrogens);
 
 protected:
   VolBox m_volbox;
@@ -35,14 +35,15 @@ protected:
 
   // These really should not be exposed as member functions.
   // They are so exposed to ease unit testing.
-  void mean_center_points(PointList &centers);
-  void get_mean_centered_cloud(const PointList &centers, PointList &cloud);
-  void find_axis_align_transform(const PointList &cloud, Transform &transform);
+  void mean_center_points(SphereList &centers);
+  void get_mean_centered_cloud(const SphereList &centers, Point3DList &cloud);
+  void find_axis_align_transform(const Point3DList &cloud,
+                                 Transform &transform);
 
-  void get_mean_center(const PointList &centers, Point &mean);
-  void untranslate_points(PointList &all_centers, const Point &offset);
-  void transform_points(PointList &all_centers, Transform &transform);
+  void get_mean_center(const SphereList &centers, Point3D &mean);
+  void untranslate_points(SphereList &all_centers, const Point3D &offset);
+  void transform_points(SphereList &all_centers, Transform &transform);
   void update_atom_coords(mesaac::mol::AtomVector &atoms,
-                          const PointList &all_centers);
+                          const SphereList &all_centers);
 };
 } // namespace mesaac::shape

--- a/src/lib/mesaac_shape/include/mesaac_shape/fingerprinter.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/fingerprinter.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "mesaac_common/shape_defs.hpp"
 #include "mesaac_mol/atom.hpp"
 #include "mesaac_shape/vol_box.hpp"
 

--- a/src/lib/mesaac_shape/include/mesaac_shape/fingerprinter.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/fingerprinter.hpp
@@ -20,7 +20,7 @@ public:
 protected:
   const VolBox &m_volbox;
 
-  void compute_for_flip(const PointList &points, unsigned int i_flip,
+  void compute_for_flip(const SphereList &centers, unsigned int i_flip,
                         Fingerprint &result);
 
 private:

--- a/src/lib/mesaac_shape/include/mesaac_shape/fingerprinter.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/fingerprinter.hpp
@@ -19,9 +19,6 @@ public:
 protected:
   const VolBox &m_volbox;
 
-  void compute_for_flip(const SphereList &centers, unsigned int i_flip,
-                        Fingerprint &result);
-
 private:
   Fingerprinter(const Fingerprinter &src);
   Fingerprinter &operator=(const Fingerprinter &src);

--- a/src/lib/mesaac_shape/include/mesaac_shape/hammersley.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/hammersley.hpp
@@ -94,20 +94,20 @@ struct Hammersley {
    * @param params specifies the point set to be generated
    * @param result on return, the generated points
    */
-  static void get_ellipsoid(const EllipsoidParams &params, PointList &result);
+  static void get_ellipsoid(const EllipsoidParams &params, Point3DList &result);
 
   /**
    * @brief Get a Hammersley cuboid point set.
    * @param params specifies the point set to be generated
    * @param result on return, the generated points
    */
-  static void get_cuboid(const CuboidParams &params, PointList &result);
+  static void get_cuboid(const CuboidParams &params, Point3DList &result);
 
 private:
   const size_t m_num_points;
   unsigned int m_point_index;
 
-  Point next_point();
+  Point3D next_point();
 };
 
 } // namespace mesaac::shape

--- a/src/lib/mesaac_shape/include/mesaac_shape/shared_types.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/shared_types.hpp
@@ -4,20 +4,22 @@
 #pragma once
 
 #include "mesaac_common/shape_defs.hpp"
+#include <array>
 #include <vector>
-
 namespace mesaac::shape {
 
 /**
- * @brief A Point is a sequence of coordinates.  It typically holds x, y, z
- * coordinates.  In some uses it also holds a radius, e.g., for an Atom.
+ * @brief A Point3D is a location in 3-space: {x, y, z}
  */
-using Point = std::vector<float>;
+using Point3D = std::array<float, 3>;
 
 /**
- * @brief A vector of Points.
+ * @brief A Sphere is represented as a location and a radius: {x, y, z, radius}
  */
-using PointList = std::vector<Point>;
+using Sphere = std::array<float, 4>;
+
+using Point3DList = std::vector<Point3D>;
+using SphereList = std::vector<Sphere>;
 
 /**
  * @brief Represents a single shape (conformer) for a single orientation.

--- a/src/lib/mesaac_shape/include/mesaac_shape/vol_box.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/vol_box.hpp
@@ -8,11 +8,6 @@
 namespace mesaac::shape {
 // Vector of indices, i.e. indices of points which lie within a volume.
 using IndexList = std::vector<unsigned int>;
-struct IndexedPoint {
-  unsigned int index;
-  float x, y, z;
-};
-using IndexedPointList = std::vector<IndexedPoint>;
 
 using ZBucket = std::vector<IndexList>;
 using YZBucket = std::vector<ZBucket>;
@@ -22,8 +17,7 @@ class VolBox {
 public:
   using VolBoxPtr = std::shared_ptr<VolBox>;
 
-  VolBox() {}
-  VolBox(const PointList &points, const float sphere_scale);
+  VolBox(const Point3DList &points, const float sphere_scale);
 
   // Get the number of points within this VolBox.
   unsigned int size();
@@ -32,19 +26,20 @@ public:
   //       x, y, z, radius
   // If from_scratch is true, then bits are cleared and resized to
   // match self's number of points.
-  void set_bits_for_spheres(const PointList &spheres,
+  void set_bits_for_spheres(const SphereList &spheres,
                             shape_defs::BitVector &bits, bool from_scratch,
                             unsigned int offset) const;
 
-  void set_bits_for_one_sphere(const Point &sphere, shape_defs::BitVector &bits,
+  void set_bits_for_one_sphere(const Sphere &sphere,
+                               shape_defs::BitVector &bits,
                                unsigned int offset) const;
 
-  void get_points_within_spheres(const PointList &spheres,
-                                 PointList &contained_points,
+  void get_points_within_spheres(const SphereList &spheres,
+                                 Point3DList &contained_points,
                                  unsigned int offset) const;
 
   // For folded fingerprints:
-  void set_folded_bits_for_spheres(const PointList &spheres,
+  void set_folded_bits_for_spheres(const SphereList &spheres,
                                    shape_defs::BitVector &bits,
                                    unsigned int num_folds,
                                    unsigned int offset) const;
@@ -57,13 +52,13 @@ protected:
   int m_ixmax, m_iymax, m_izmax;
 
   XYZBucket m_bucket;
-  PointList m_bucket_points;
+  Point3DList m_bucket_points;
 
-  void add_points(const PointList &points);
-  void set_bits_for_one_sphere_unchecked(const Point &sphere,
+  void add_points(const Point3DList &points);
+  void set_bits_for_one_sphere_unchecked(const Sphere &sphere,
                                          shape_defs::BitVector &bits,
                                          unsigned int offset) const;
-  void set_folded_bits_for_one_sphere_unchecked(const Point &sphere,
+  void set_folded_bits_for_one_sphere_unchecked(const Sphere &sphere,
                                                 shape_defs::BitVector &bits,
                                                 unsigned int offset,
                                                 unsigned int folded_size) const;

--- a/src/lib/mesaac_shape/src/axis_aligner.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner.cpp
@@ -3,10 +3,12 @@
 //
 
 #include "mesaac_shape/axis_aligner.hpp"
-#include "mesaac_mol/mol.hpp"
 
 #include <format>
 #include <stdexcept>
+
+#include "mesaac_mol/mol.hpp"
+#include "svd.h"
 
 using namespace std;
 

--- a/src/lib/mesaac_shape/src/axis_aligner.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner.cpp
@@ -80,7 +80,7 @@ void unmirror_axes(Transform &vt) {
 template <typename PointListType, typename PointType>
 void get_mean_center_impl(const PointListType &points, PointType &mean) {
   mean = {0, 0, 0};
-  if (points.size() > 0) {
+  if (!points.empty()) {
     float xsum = 0, ysum = 0, zsum = 0;
     for (const auto &point : points) {
       xsum += point[0];
@@ -124,7 +124,7 @@ void AxisAligner::align_to_axes(mol::AtomVector &atoms) {
   //   Get mean-centered cloud points
   //   Find the axis-aligning rotation matrix using SVD
   //   Transform the original coordinates: mean center and rotate
-  if (atoms.size() > 0) {
+  if (!atoms.empty()) {
     SphereList centers;
     Point3DList cloud;
     Transform transform;

--- a/src/lib/mesaac_shape/src/axis_aligner.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner.cpp
@@ -38,10 +38,7 @@ bool axis_is_mirrored(Transform &vt) {
   // Transform 3 unit "vectors" such that the 3rd is the cross product
   // of the first 2.  After transformation, confirm it is still the
   // cross product.
-  Point3D a{0, 0, 0}, b{0, 0, 0}, c{0, 0, 0};
-  a[0] = 1.0;
-  b[1] = 1.0;
-  c[2] = 1.0;
+  Point3D a{1, 0, 0}, b{0, 1, 0}, c{0, 0, 1};
   transform_point(vt, a);
   transform_point(vt, b);
   transform_point(vt, c);
@@ -81,8 +78,9 @@ void unmirror_axes(Transform &vt) {
 
 template <typename PointListType, typename PointType>
 void get_mean_center_impl(const PointListType &points, PointType &mean) {
-  mean = {0, 0, 0};
-  if (!points.empty()) {
+  if (points.empty()) {
+    mean = {0, 0, 0};
+  } else {
     float xsum = 0, ysum = 0, zsum = 0;
     for (const auto &point : points) {
       xsum += point[0];

--- a/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
@@ -25,7 +25,6 @@ bool axis_is_mirrored(Transform &vt) {
   // of auto-vectorization packet sizes.
   typedef Eigen::Vector3f EPoint;
   EPoint a, b, c;
-  // Why is this epsilon faster than EPoint(1.0, 0.0, 0.0) etc.?
   a << 1.0, 0.0, 0.0;
   b << 0.0, 1.0, 0.0;
   c << 0.0, 0.0, 1.0;
@@ -52,8 +51,9 @@ void unmirror_axes(Transform &vt) {
 
 template <typename PointListType, typename PointType>
 void get_mean_center_impl(const PointListType &points, PointType &mean) {
-  mean = {0, 0, 0};
-  if (!points.empty()) {
+  if (points.empty()) {
+    mean = {0, 0, 0};
+  } else {
     float xsum = 0, ysum = 0, zsum = 0;
     for (const auto &point : points) {
       xsum += point[0];

--- a/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
@@ -53,7 +53,7 @@ void unmirror_axes(Transform &vt) {
 template <typename PointListType, typename PointType>
 void get_mean_center_impl(const PointListType &points, PointType &mean) {
   mean = {0, 0, 0};
-  if (points.size() > 0) {
+  if (!points.empty()) {
     float xsum = 0, ysum = 0, zsum = 0;
     for (const auto &point : points) {
       xsum += point[0];
@@ -93,7 +93,7 @@ void AxisAlignerEigen::align_to_axes(mol::AtomVector &atoms) {
   //   Get mean-centered cloud points
   //   Find the axis-aligning rotation matrix using SVD
   //   Transform the original coordinates: mean center and rotate
-  if (atoms.size() > 0) {
+  if (!atoms.empty()) {
     SphereList centers;
     Point3DList cloud;
     Transform transform;

--- a/src/lib/mesaac_shape/src/fingerprinter.cpp
+++ b/src/lib/mesaac_shape/src/fingerprinter.cpp
@@ -21,7 +21,7 @@ const static float c_flip_matrix[4][3] = {{1.0, 1.0, 1.0}, // Unflipped
 const static unsigned int c_flip_matrix_size =
     sizeof(c_flip_matrix) / sizeof(c_flip_matrix[0]);
 
-inline void get_point_list(const AtomVector &atoms, PointList &result) {
+inline void get_point_list(const AtomVector &atoms, SphereList &result) {
   result.clear();
   result.reserve(atoms.size());
   for (const Atom &atom : atoms) {
@@ -30,9 +30,9 @@ inline void get_point_list(const AtomVector &atoms, PointList &result) {
   }
 }
 
-inline void get_flipped_points(const PointList &points, const float *flip,
-                               PointList &flipped) {
-  flipped = points;
+inline void get_flipped_points(const SphereList &centers, const float *flip,
+                               SphereList &flipped) {
+  flipped = centers;
 
   for (auto &point : flipped) {
     point[0] *= flip[0];
@@ -48,7 +48,7 @@ Fingerprinter::Fingerprinter(const VolBox &volbox) : m_volbox(volbox) {}
 void Fingerprinter::compute(const AtomVector &atoms, ShapeFingerprint &result) {
   result.clear();
   result.reserve(c_flip_matrix_size);
-  PointList centers;
+  SphereList centers;
   get_point_list(atoms, centers);
   for (unsigned int i = 0; i != c_flip_matrix_size; i++) {
     shape_defs::BitVector curr_fp;
@@ -57,11 +57,11 @@ void Fingerprinter::compute(const AtomVector &atoms, ShapeFingerprint &result) {
   }
 }
 
-void Fingerprinter::compute_for_flip(const PointList &points,
+void Fingerprinter::compute_for_flip(const SphereList &centers,
                                      unsigned int i_flip, Fingerprint &result) {
   result.reset();
-  PointList flipped;
-  get_flipped_points(points, c_flip_matrix[i_flip], flipped);
+  SphereList flipped;
+  get_flipped_points(centers, c_flip_matrix[i_flip], flipped);
   m_volbox.set_bits_for_spheres(flipped, result, true, 0);
 }
 

--- a/src/lib/mesaac_shape/src/hammersley.cpp
+++ b/src/lib/mesaac_shape/src/hammersley.cpp
@@ -70,7 +70,7 @@ float hamm_dim_n(const unsigned int dimension, const unsigned int index) {
 }
 } // namespace
 
-Point Hammersley::next_point() {
+Point3D Hammersley::next_point() {
   // Get the next hammersley point that lies within the spheroid.
   for (;;) {
     m_point_index += 1;
@@ -86,8 +86,8 @@ Point Hammersley::next_point() {
 }
 
 void Hammersley::get_ellipsoid(const Hammersley::EllipsoidParams &params,
-                               std::vector<Point> &result) {
-  const Point zero{0, 0, 0};
+                               Point3DList &result) {
+  const Point3D zero{0, 0, 0};
 
   const float scale_2 = params.scale * 2.0;
   const float scale_sqr = params.scale * params.scale;
@@ -123,7 +123,7 @@ void Hammersley::get_ellipsoid(const Hammersley::EllipsoidParams &params,
       return;
     }
 
-    const Point raw_point = gen.next_point();
+    const Point3D raw_point = gen.next_point();
     if (raw_point == zero) {
       // No more points available
       std::cerr << "DBG: get_ellipsoid ran out of points after filling "
@@ -143,13 +143,13 @@ void Hammersley::get_ellipsoid(const Hammersley::EllipsoidParams &params,
     const float ysqr = y * y / params.b;
     const float zsqr = z * z / params.c;
     if ((xsqr + ysqr + zsqr) < scale_sqr) {
-      result.emplace_back(Point{x, y, z});
+      result.emplace_back(Point3D{x, y, z});
     }
   }
 }
 
-void Hammersley::get_cuboid(const CuboidParams &params, PointList &result) {
-  const Point zero{0, 0, 0};
+void Hammersley::get_cuboid(const CuboidParams &params, Point3DList &result) {
+  const Point3D zero{0, 0, 0};
   result.clear();
   result.reserve(params.num_points);
 
@@ -179,7 +179,7 @@ void Hammersley::get_cuboid(const CuboidParams &params, PointList &result) {
           return;
         }
 
-        const Point raw_point = gen.next_point();
+        const Point3D raw_point = gen.next_point();
         if (raw_point == zero) {
           // No more points available
           return;
@@ -188,9 +188,9 @@ void Hammersley::get_cuboid(const CuboidParams &params, PointList &result) {
         const float x(raw_point[0]), y(raw_point[1]), z(raw_point[2]);
         if ((x <= dx) && (y <= dy) && (z <= dz)) {
           // Shift points to center.
-          result.emplace_back(Point{(x * dw_max) + params.xmin,
-                                    (y * dw_max) + params.ymin,
-                                    (z * dw_max) + params.zmin});
+          result.emplace_back(Point3D{(x * dw_max) + params.xmin,
+                                      (y * dw_max) + params.ymin,
+                                      (z * dw_max) + params.zmin});
         }
       }
     }

--- a/tests/src/lib/mesaac_measures/test_shape_measures_factory.cpp
+++ b/tests/src/lib/mesaac_measures/test_shape_measures_factory.cpp
@@ -5,11 +5,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include <cmath>
-#include <fstream>
-#include <functional>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 #include "mesaac_measures/bub.hpp"
@@ -235,8 +231,7 @@ void test_measurer(FPGroupGen &&fp_gen) {
             << bit_vectors[i] << ", " << hex << bit_vectors[j] << ": expected "
             << sim_cat_str(expected_category) << "; got "
             << sim_cat_str(actual_category) << ", value " << actual_value;
-        INFO(msg.str());
-        CHECK(false);
+        FAIL(msg.str());
       }
     }
   }
@@ -292,8 +287,7 @@ void test_shape_measurer(FPGroupGen &&fp_gen) {
         ostringstream msg;
         msg << "For " << fp_gen.name() << ", values " << hex << i << ", " << hex
             << j << "; expected best_sim " << best_sim << ", got " << actual;
-        INFO(msg.str());
-        CHECK(false);
+        FAIL(msg.str());
       }
 
       all_fps.pop_back();

--- a/tests/src/lib/mesaac_mol/io/test_sdreader_v3000.cpp
+++ b/tests/src/lib/mesaac_mol/io/test_sdreader_v3000.cpp
@@ -79,8 +79,7 @@ $$$$
   const auto read_result = reader.read();
 
   if (!read_result.is_ok()) {
-    std::cerr << read_result.error() << std::endl;
-    FAIL();
+    FAIL(read_result.error());
   }
 
   const auto mol = read_result.value();

--- a/tests/src/lib/mesaac_mol/io/test_sdwriter.cpp
+++ b/tests/src/lib/mesaac_mol/io/test_sdwriter.cpp
@@ -4,9 +4,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <filesystem>
 #include <format>
 #include <fstream>
-#include <filesystem>
 
 #include "mesaac_mol/io.hpp"
 
@@ -122,13 +122,8 @@ TEST_CASE("mesaac::mol::SDWriter - Basic writing", "[mesaac]") {
       i_mol_line = 0;
     }
   }
-  if (actualf) {
-    // Actual output has more lines than expected.
-    has_diffs = true;
-  } else if (expectedf) {
-    // Actual output has fewer lines than expected.
-    has_diffs = true;
-  }
+  // Does either of actual or expected have more lines than expected?
+  has_diffs |= (actualf || expectedf);
   // If there are diffs, write out the actual for manual comparison
   // against the expected.
   if (has_diffs) {
@@ -136,10 +131,8 @@ TEST_CASE("mesaac::mol::SDWriter - Basic writing", "[mesaac]") {
     ofstream actf(out_path);
     actf << outs.str();
     actf.close();
-    const string msg = std::format(
-        "Expected output {} does not match actual {}", std::string(in_path),
-        std::string(filesystem::absolute(out_path)));
-    FAIL(msg);
+    FAIL(format("Expected output {} does not match actual {}", string(in_path),
+                string(filesystem::absolute(out_path))));
   }
 }
 
@@ -176,9 +169,8 @@ TEST_CASE("mesaac::mol::SDWriter - Malformed empty tag", "[mesaac]") {
                 << endl
                 << ">  <non_empty>" << endl;
       if (string::npos == s.find(empty_tag.str())) {
-        cerr << "Did not find expected empty tag in '" << s << "'." << endl;
+        FAIL("Did not find expected empty tag in '" + s + "'.");
       }
-      REQUIRE(string::npos != s.find(empty_tag.str()));
       occurrences++;
     }
   }

--- a/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
@@ -324,34 +324,34 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   TestFixture fixture;
   std::unique_ptr<TCAxisAligner> aligner(fixture.new_aligner());
   mol::AtomVector atoms;
-  SphereList points;
+  SphereList centers;
 
   SECTION("Get atom coords from an empty vector of atoms") {
-    aligner->tc_get_atom_points(atoms, points, false);
+    aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE((size_t)0 == atoms.size());
-    REQUIRE((size_t)0 == points.size());
-    aligner->tc_get_atom_points(atoms, points, true);
+    REQUIRE((size_t)0 == centers.size());
+    aligner->tc_get_atom_points(atoms, centers, true);
     REQUIRE((size_t)0 == atoms.size());
-    REQUIRE((size_t)0 == points.size());
+    REQUIRE((size_t)0 == centers.size());
   }
 
   SECTION("Get atom coords from a vector of heavy atoms") {
     unsigned int num_heavies;
 
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
+    aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE(atoms.size() > num_heavies);
     REQUIRE(num_heavies > 0);
-    REQUIRE(fixture.coords_match(atoms, points, num_heavies));
+    REQUIRE(fixture.coords_match(atoms, centers, num_heavies));
 
-    aligner->tc_get_atom_points(atoms, points, true);
-    REQUIRE(fixture.coords_match(atoms, points, atoms.size()));
+    aligner->tc_get_atom_points(atoms, centers, true);
+    REQUIRE(fixture.coords_match(atoms, centers, atoms.size()));
   }
 
   SECTION("Get the mean center of an empty list of points") {
     Point3D center;
 
-    aligner->tc_get_mean_center(points, center);
+    aligner->tc_get_mean_center(centers, center);
     REQUIRE(center.size() == 3);
     REQUIRE(center[0] == 0.0f);
     REQUIRE(center[1] == 0.0f);
@@ -363,8 +363,8 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     Point3D center;
 
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    aligner->tc_get_mean_center(points, center);
+    aligner->tc_get_atom_points(atoms, centers, false);
+    aligner->tc_get_mean_center(centers, center);
     REQUIRE(center.size() == 3);
 
     // FRAGILE
@@ -375,10 +375,10 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
   SECTION("Translate an empty list of points so that its mean center lies at "
           "the origin") {
-    REQUIRE(points.empty());
-    aligner->tc_mean_center_points(points);
+    REQUIRE(centers.empty());
+    aligner->tc_mean_center_points(centers);
     // If execution reaches this point without crashing, the test passes.
-    REQUIRE(points.empty());
+    REQUIRE(centers.empty());
   }
 
   SECTION("Translate a vector of heavy atoms so its mean center lies at the "
@@ -389,14 +389,14 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     // TODO:  create a set of atoms w. known positions and
     // easily verified extents.
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE((size_t)num_heavies == points.size());
-    aligner->tc_mean_center_points(points);
-    REQUIRE((size_t)num_heavies == points.size());
-    REQUIRE(fixture.is_mean_centered(points));
+    aligner->tc_get_atom_points(atoms, centers, false);
+    REQUIRE((size_t)num_heavies == centers.size());
+    aligner->tc_mean_center_points(centers);
+    REQUIRE((size_t)num_heavies == centers.size());
+    REQUIRE(fixture.is_mean_centered(centers));
 
     float xmid, ymid, zmid, width, height, depth;
-    fixture.get_pointlist_info(points, xmid, ymid, zmid, width, height, depth);
+    fixture.get_pointlist_info(centers, xmid, ymid, zmid, width, height, depth);
     REQUIRE_THAT(width, Catch::Matchers::WithinAbs(9.9782, 0.00001));
     REQUIRE_THAT(height, Catch::Matchers::WithinAbs(4.4967, 0.00001));
     REQUIRE_THAT(depth, Catch::Matchers::WithinAbs(6.8714, 0.00001));
@@ -404,8 +404,8 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
   SECTION("Get mean-centered cloud -- empty") {
     Point3DList cloud;
-    REQUIRE(points.empty());
-    aligner->tc_get_mean_centered_cloud(points, cloud);
+    REQUIRE(centers.empty());
+    aligner->tc_get_mean_centered_cloud(centers, cloud);
     // If we get here without crashing, we win.
     REQUIRE(cloud.empty());
   }
@@ -414,19 +414,19 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     unsigned int num_heavies;
     Point3DList cloud;
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!points.empty());
-    REQUIRE(points.size() == num_heavies);
-    aligner->tc_mean_center_points(points);
-    REQUIRE(points.size() == num_heavies);
+    aligner->tc_get_atom_points(atoms, centers, false);
+    REQUIRE(!centers.empty());
+    REQUIRE(centers.size() == num_heavies);
+    aligner->tc_mean_center_points(centers);
+    REQUIRE(centers.size() == num_heavies);
 
-    aligner->tc_get_mean_centered_cloud(points, cloud);
+    aligner->tc_get_mean_centered_cloud(centers, cloud);
     REQUIRE(!cloud.empty());
 
     float xmid, ymid, zmid, pwidth, pheight, pdepth;
-    fixture.get_pointlist_info(points, xmid, ymid, zmid, pwidth, pheight,
+    fixture.get_pointlist_info(centers, xmid, ymid, zmid, pwidth, pheight,
                                pdepth);
-    REQUIRE(fixture.is_mean_centered(points));
+    REQUIRE(fixture.is_mean_centered(centers));
     REQUIRE_THAT(pwidth, Catch::Matchers::WithinAbs(9.9782, 0.00001));
     REQUIRE_THAT(pheight, Catch::Matchers::WithinAbs(4.4967, 0.00001));
     REQUIRE_THAT(pdepth, Catch::Matchers::WithinAbs(6.8714, 0.00001));
@@ -434,7 +434,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     float cwidth, cheight, cdepth;
     fixture.get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight,
                                cdepth);
-    float dmax = 2.0 * fixture.find_max_radius(points);
+    float dmax = 2.0 * fixture.find_max_radius(centers);
 
     // Hardwired badness: max radius of all atoms in create_sample_atoms should
     // be that of sulfur.
@@ -457,9 +457,9 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     unsigned int num_heavies;
 
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    aligner->tc_mean_center_points(points);
-    aligner->tc_get_mean_centered_cloud(points, cloud);
+    aligner->tc_get_atom_points(atoms, centers, false);
+    aligner->tc_mean_center_points(centers);
+    aligner->tc_get_mean_centered_cloud(centers, cloud);
 
     // Not sure how to test this.  Just confirm it's a 3x3 matrix
     // with non-empty cells?
@@ -469,32 +469,32 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE(fixture.is_non_null_transform(transform));
   }
 
-  SECTION("Untranslate points") {
+  SECTION("Untranslate centers") {
     Point3D offset{1.0, 2.0, 3.0};
 
-    SphereList points;
+    SphereList centers;
 
     // Ensure proper handling of empty lists:
-    aligner->tc_untranslate_points(points, offset);
-    REQUIRE(points.empty());
+    aligner->tc_untranslate_points(centers, offset);
+    REQUIRE(centers.empty());
 
     unsigned int i;
     const unsigned int i_max = 10;
     for (i = 0; i != i_max; i++) {
-      points.push_back({i + 1.0f, i + 2.0f, i + 3.0f});
+      centers.push_back({i + 1.0f, i + 2.0f, i + 3.0f});
     }
 
-    aligner->tc_untranslate_points(points, offset);
+    aligner->tc_untranslate_points(centers, offset);
     for (i = 0; i != i_max; i++) {
       float f(i);
-      Sphere &p(points[i]);
+      Sphere &p(centers[i]);
       REQUIRE_THAT(p.at(0), Catch::Matchers::WithinAbs(f, 0.00001));
       REQUIRE_THAT(p.at(1), Catch::Matchers::WithinAbs(f, 0.00001));
       REQUIRE_THAT(p.at(2), Catch::Matchers::WithinAbs(f, 0.00001));
     }
   }
 
-  SECTION("Transform points") {
+  SECTION("Transform centers") {
     Point3DList cloud;
     unsigned int num_heavies;
     Transform transform;
@@ -504,27 +504,27 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
                       invalid_argument);
 
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    aligner->tc_mean_center_points(points);
-    aligner->tc_get_mean_centered_cloud(points, cloud);
+    aligner->tc_get_atom_points(atoms, centers, false);
+    aligner->tc_mean_center_points(centers);
+    aligner->tc_get_mean_centered_cloud(centers, cloud);
 
     REQUIRE(!fixture.is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
     REQUIRE(fixture.is_non_null_transform(transform));
 
     // Verify no crash on an empty point list.
-    points.clear();
-    aligner->tc_transform_points(points, transform);
-    REQUIRE(points.empty());
+    centers.clear();
+    aligner->tc_transform_points(centers, transform);
+    REQUIRE(centers.empty());
 
-    aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(atoms, centers, false);
+    REQUIRE(!fixture.has_nonincreasing_extents(centers));
 
-    aligner->tc_transform_points(points, transform);
-    REQUIRE(points.size() == num_heavies);
+    aligner->tc_transform_points(centers, transform);
+    REQUIRE(centers.size() == num_heavies);
 
     // Transform should merely rotate the points -- no mean-centering.
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(fixture.has_nonincreasing_extents(centers));
   }
 
   SECTION("Update atom coords") {
@@ -536,19 +536,19 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     fixture.create_sample_atoms(atoms, num_heavies);
 
     // Point and atom lists of different size?  This should fail.
-    aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE_THROWS_AS(aligner->tc_update_atom_coords(atoms, points),
+    aligner->tc_get_atom_points(atoms, centers, false);
+    REQUIRE_THROWS_AS(aligner->tc_update_atom_coords(atoms, centers),
                       std::length_error);
 
     // Moronic, but maybe adequate, test: superpose all atoms.
-    aligner->tc_get_atom_points(atoms, points, true);
+    aligner->tc_get_atom_points(atoms, centers, true);
     Point3D offset{10.0, -50.0, 0.0};
-    for (auto &point : points) {
+    for (auto &point : centers) {
       point.at(0) = offset[0];
       point.at(1) = offset[1];
       point.at(2) = offset[2];
     }
-    aligner->tc_update_atom_coords(atoms, points);
+    aligner->tc_update_atom_coords(atoms, centers);
 
     for (const auto &atom : atoms) {
       const auto &pos(atom.pos());
@@ -563,20 +563,20 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     aligner->align_to_axes(atoms);
     REQUIRE(atoms.empty());
 
-    SphereList points;
+    SphereList centers;
     Point3DList cloud;
     unsigned int num_heavies;
 
     fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(atoms, centers, false);
+    REQUIRE(!fixture.is_mean_centered(centers));
+    REQUIRE(!fixture.has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(atoms);
-    aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(atoms, centers, false);
+    REQUIRE(fixture.is_mean_centered(centers));
+    REQUIRE(fixture.has_nonincreasing_extents(centers));
   }
 
   SECTION("Align mol to axes") {
@@ -586,20 +586,20 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     aligner->align_to_axes(mol);
     REQUIRE(mol.atoms().empty());
 
-    SphereList points;
+    SphereList centers;
     Point3DList cloud;
     unsigned int num_heavies;
 
     fixture.create_sample_mol(mol, num_heavies);
-    aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(mol.atoms(), centers, false);
+    REQUIRE(!fixture.is_mean_centered(centers));
+    REQUIRE(!fixture.has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(mol);
-    aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(mol.atoms(), centers, false);
+    REQUIRE(fixture.is_mean_centered(centers));
+    REQUIRE(fixture.has_nonincreasing_extents(centers));
   }
 
   SECTION("Align to axes - mol only") {
@@ -610,22 +610,22 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     aligner->align_to_axes(mol);
     REQUIRE(mol.atoms().empty());
 
-    SphereList points;
+    SphereList centers;
     Point3DList cloud;
     unsigned int num_heavies;
 
     fixture.create_sample_mol(mol, num_heavies);
-    aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(mol.atoms(), centers, false);
+    REQUIRE(!fixture.is_mean_centered(centers));
+    REQUIRE(!fixture.has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     // TODO:  Check that align_to_axes with atom-centers-only produces
     // different results than without atom-centers-only.
     aligner->align_to_axes(mol);
-    aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    aligner->tc_get_atom_points(mol.atoms(), centers, false);
+    REQUIRE(fixture.is_mean_centered(centers));
+    REQUIRE(fixture.has_nonincreasing_extents(centers));
   }
 
   SECTION("Align hydrogens") {
@@ -647,17 +647,17 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
              fixture.atom("H", 0.0, 0.0, 7.0),
          }});
 
-    aligner->tc_get_atom_points(mol.atoms(), points, true);
-    fixture.get_pointlist_info(points, x, y, z, w, h, d);
+    aligner->tc_get_atom_points(mol.atoms(), centers, true);
+    fixture.get_pointlist_info(centers, x, y, z, w, h, d);
 
     REQUIRE_THAT(w, Catch::Matchers::WithinAbs(0.0f, 0.00001));
     REQUIRE_THAT(h, Catch::Matchers::WithinAbs(0.0f, 0.00001));
     REQUIRE_THAT(d, Catch::Matchers::WithinAbs(7.0f, 0.00001));
 
     aligner->align_to_axes(mol);
-    aligner->tc_get_atom_points(mol.atoms(), points, true);
+    aligner->tc_get_atom_points(mol.atoms(), centers, true);
 
-    fixture.get_pointlist_info(points, x, y, z, w, h, d);
+    fixture.get_pointlist_info(centers, x, y, z, w, h, d);
 
     // The slope from point to point should be consistent.
     const float dx_dy = w / h;
@@ -693,9 +693,9 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     // will not be double-counted.
 
     const Sphere atom({0, 0, 0, 170.0});
-    SphereList mol1{atom};
+    const SphereList mol1{atom};
     // Duplicates, superposed!
-    SphereList mol2{atom, atom};
+    const SphereList mol2{atom, atom};
 
     Point3DList contained1, contained2;
     aligner->tc_get_mean_centered_cloud(mol1, contained1);
@@ -710,16 +710,16 @@ namespace {
 int benchmark_align_to_axes(const TestFixture &fixture,
                             std::shared_ptr<TCAxisAligner> aligner) {
   mol::Mol mol;
-  SphereList points;
+  SphereList centers;
   Point3DList cloud;
   unsigned int num_heavies;
 
   fixture.create_sample_mol(mol, num_heavies);
-  aligner->tc_get_atom_points(mol.atoms(), points, false);
+  aligner->tc_get_atom_points(mol.atoms(), centers, false);
 
   // TODO:  Check that the hydrogens are also transformed.
   aligner->align_to_axes(mol);
-  aligner->tc_get_atom_points(mol.atoms(), points, false);
+  aligner->tc_get_atom_points(mol.atoms(), centers, false);
   return 0;
 }
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
@@ -64,265 +64,217 @@ public:
   }
 };
 
-class TestFixture {
-public:
-  void get_point_means(const Point3DList &points, float &x, float &y,
-                       float &z) {
-    x = y = z = 0.0;
-    if (points.size()) {
-      float xsum = 0, ysum = 0, zsum = 0;
-      for (const auto p : points) {
-        xsum += p[0];
-        ysum += p[1];
-        zsum += p[2];
-      }
-      x = xsum / points.size();
-      y = ysum / points.size();
-      z = zsum / points.size();
-    }
+void read_test_points(const filesystem::path &pathname, Point3DList &points) {
+  // Use the test data directory specified by TEST_DATA_DIR preprocessor
+  // symbol.
+  const filesystem::path test_data_dir(TEST_DATA_DIR);
+  const auto data_dir(test_data_dir / "hammersley/");
+  const auto full_path(data_dir / pathname);
+  points.clear();
+  ifstream inf(full_path);
+  if (!inf) {
+    ostringstream msg;
+    msg << "Could not open " << pathname << " for reading." << endl;
+    throw std::runtime_error(msg.str());
   }
-
-  // Find the extent of set of points, along each axis.
-  void get_point_extents(const Point3DList &points, float &dx, float &dy,
-                         float &dz) {
-    dx = dy = dz = 0.0;
-    if (points.size()) {
-      bool first = true;
-      float xmin = 0, ymin = 0, zmin = 0, xmax = 0, ymax = 0, zmax = 0;
-      for (const auto &p : points) {
-        if (first) {
-          xmin = xmax = p[0];
-          ymin = ymax = p[1];
-          zmin = zmax = p[2];
-          first = false;
-        } else {
-          xmin = min(xmin, p[0]);
-          xmax = max(xmax, p[0]);
-          ymin = min(ymin, p[1]);
-          ymax = max(ymax, p[1]);
-          zmin = min(zmin, p[2]);
-          zmax = max(zmax, p[2]);
-        }
-      }
-      dx = xmax - xmin;
-      dy = ymax - ymin;
-      dz = zmax - zmin;
-    }
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    points.push_back({x, y, z});
   }
+  inf.close();
+}
 
-  void read_test_points(const filesystem::path &pathname, Point3DList &points) {
-    // Use the test data directory specified by TEST_DATA_DIR preprocessor
-    // symbol.
-    const filesystem::path test_data_dir(TEST_DATA_DIR);
-    const auto data_dir(test_data_dir / "hammersley/");
-    const auto full_path(data_dir / pathname);
-    points.clear();
-    ifstream inf(full_path);
-    if (!inf) {
-      ostringstream msg;
-      msg << "Could not open " << pathname << " for reading." << endl;
-      throw std::runtime_error(msg.str());
-    }
-    float x, y, z;
-    while (inf >> x >> y >> z) {
-      points.push_back({x, y, z});
-    }
-    inf.close();
+std::unique_ptr<TCAxisAligner> new_aligner() {
+  Point3DList sphere;
+  float atom_scale = 1.0;
+
+  // Assume we will be run in a location fixed relative to
+  // the data files.
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAligner>(sphere, atom_scale, false);
+}
+
+std::unique_ptr<TCAxisAligner> new_aligner_ac_only() {
+  Point3DList sphere;
+  float atom_scale = 1.0;
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAligner>(sphere, atom_scale, true);
+}
+
+mol::Atom atom(string symbol, float x, float y, float z) {
+  const unsigned char atomic_num(mol::get_atomic_num(symbol));
+  return mol::Atom({atomic_num, {x, y, z}});
+}
+
+void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) {
+  // Coordinates taken from first cox2_3d conformer.
+  mol::AtomVector atoms{
+      atom("C", 27.7051, 22.0403, 17.0243),
+      atom("N", 26.4399, 22.0976, 16.4318),
+      atom("C", 25.5381, 21.4424, 17.2831),
+      atom("C", 26.2525, 20.9753, 18.3748),
+      atom("C", 27.5943, 21.3608, 18.2218),
+      atom("C", 24.0821, 21.3670, 17.1082),
+      atom("C", 26.1324, 22.6824, 15.1634),
+      atom("C", 23.4105, 22.2668, 16.2675),
+      atom("C", 22.0220, 22.2007, 16.1197),
+      atom("C", 21.2976, 21.2409, 16.8307),
+      atom("C", 21.9509, 20.3402, 17.6750),
+      atom("C", 23.3399, 20.4115, 17.8175),
+      atom("C", 26.3695, 24.0457, 14.9358),
+      atom("C", 26.0627, 24.6119, 13.6959),
+      atom("C", 25.5236, 23.8179, 12.6910),
+      atom("C", 25.2821, 22.4660, 12.9010),
+      atom("C", 25.5848, 21.8942, 14.1391),
+      atom("F", 25.2311, 24.3643, 11.5034),
+      atom("C", 28.9655, 22.5443, 16.4025),
+      atom("S", 19.5328, 21.1457, 16.6315),
+      atom("O", 19.0413, 22.4851, 16.3229),
+      atom("O", 18.9873, 20.4577, 17.7975),
+      atom("C", 19.3258, 20.1152, 15.2035),
+      atom("H", 25.8309, 20.4354, 19.2156),
+      atom("H", 28.4100, 21.1477, 18.9041),
+      atom("H", 23.9630, 23.0298, 15.7210),
+      atom("H", 21.5209, 22.9035, 15.4575),
+      atom("H", 21.3956, 19.5863, 18.2287),
+      atom("H", 23.8404, 19.7079, 18.4815),
+      atom("H", 26.7480, 24.6961, 15.7203),
+      atom("H", 26.2341, 25.6696, 13.5167),
+      atom("H", 24.8658, 21.8592, 12.1019),
+      atom("H", 25.4187, 20.8273, 14.2701),
+      atom("H", 29.8338, 22.0387, 16.8401),
+      atom("H", 29.0870, 23.6157, 16.5858),
+      atom("H", 28.9947, 22.3510, 15.3261),
+      atom("H", 18.2555, 20.0118, 15.0126),
+      atom("H", 19.7633, 19.1356, 15.4046),
+      atom("H", 19.8115, 20.5898, 14.3489),
+  };
+  mol = mol::Mol({.atoms = atoms});
+  num_heavies = 23;
+}
+
+void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
+  mol::Mol m;
+
+  create_sample_mol(m, num_heavies);
+  // Take care to deep-copy all of the atom pointers.
+  atoms.clear();
+  const mol::AtomVector &src(m.atoms());
+  for (const auto src_atom : src) {
+    atoms.push_back(src_atom);
   }
+}
 
-  std::unique_ptr<TCAxisAligner> new_aligner() {
-    Point3DList sphere;
-    float atom_scale = 1.0;
-
-    // Assume we will be run in a location fixed relative to
-    // the data files.
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAligner>(sphere, atom_scale, false);
-  }
-
-  std::unique_ptr<TCAxisAligner> new_aligner_ac_only() {
-    Point3DList sphere;
-    float atom_scale = 1.0;
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAligner>(sphere, atom_scale, true);
-  }
-
-  mol::Atom atom(string symbol, float x, float y, float z) const {
-    const unsigned char atomic_num(mol::get_atomic_num(symbol));
-    return mol::Atom({atomic_num, {x, y, z}});
-  }
-
-  void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) const {
-    // Coordinates taken from first cox2_3d conformer.
-    mol::AtomVector atoms{
-        atom("C", 27.7051, 22.0403, 17.0243),
-        atom("N", 26.4399, 22.0976, 16.4318),
-        atom("C", 25.5381, 21.4424, 17.2831),
-        atom("C", 26.2525, 20.9753, 18.3748),
-        atom("C", 27.5943, 21.3608, 18.2218),
-        atom("C", 24.0821, 21.3670, 17.1082),
-        atom("C", 26.1324, 22.6824, 15.1634),
-        atom("C", 23.4105, 22.2668, 16.2675),
-        atom("C", 22.0220, 22.2007, 16.1197),
-        atom("C", 21.2976, 21.2409, 16.8307),
-        atom("C", 21.9509, 20.3402, 17.6750),
-        atom("C", 23.3399, 20.4115, 17.8175),
-        atom("C", 26.3695, 24.0457, 14.9358),
-        atom("C", 26.0627, 24.6119, 13.6959),
-        atom("C", 25.5236, 23.8179, 12.6910),
-        atom("C", 25.2821, 22.4660, 12.9010),
-        atom("C", 25.5848, 21.8942, 14.1391),
-        atom("F", 25.2311, 24.3643, 11.5034),
-        atom("C", 28.9655, 22.5443, 16.4025),
-        atom("S", 19.5328, 21.1457, 16.6315),
-        atom("O", 19.0413, 22.4851, 16.3229),
-        atom("O", 18.9873, 20.4577, 17.7975),
-        atom("C", 19.3258, 20.1152, 15.2035),
-        atom("H", 25.8309, 20.4354, 19.2156),
-        atom("H", 28.4100, 21.1477, 18.9041),
-        atom("H", 23.9630, 23.0298, 15.7210),
-        atom("H", 21.5209, 22.9035, 15.4575),
-        atom("H", 21.3956, 19.5863, 18.2287),
-        atom("H", 23.8404, 19.7079, 18.4815),
-        atom("H", 26.7480, 24.6961, 15.7203),
-        atom("H", 26.2341, 25.6696, 13.5167),
-        atom("H", 24.8658, 21.8592, 12.1019),
-        atom("H", 25.4187, 20.8273, 14.2701),
-        atom("H", 29.8338, 22.0387, 16.8401),
-        atom("H", 29.0870, 23.6157, 16.5858),
-        atom("H", 28.9947, 22.3510, 15.3261),
-        atom("H", 18.2555, 20.0118, 15.0126),
-        atom("H", 19.7633, 19.1356, 15.4046),
-        atom("H", 19.8115, 20.5898, 14.3489),
-    };
-    mol = mol::Mol({.atoms = atoms});
-    num_heavies = 23;
-  }
-
-  void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
-    mol::Mol m;
-
-    create_sample_mol(m, num_heavies);
-    // Take care to deep-copy all of the atom pointers.
-    atoms.clear();
-    const mol::AtomVector &src(m.atoms());
-    for (const auto src_atom : src) {
-      atoms.push_back(src_atom);
-    }
-  }
-
-  bool coords_match(const mol::AtomVector &atoms, const SphereList &centers,
-                    unsigned int count) {
-    // cout << "coords_match? " << endl
-    //      << "  # atoms:    " << atoms.size() << endl
-    //      << "  # centers:   " << centers.size() << endl
-    //      << "  # to check: " << count << endl;
-    if ((atoms.size() >= count) && (centers.size() >= count)) {
-      for (int i = count - 1; i >= 0; --i) {
-        const mol::Atom &a(atoms[i]);
-        const auto &p(centers[i]);
-        const mol::Position &pos(a.pos());
-        if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
-          return false;
-        }
-      }
-      return true;
-    }
-    return false;
-  }
-
-  template <typename PointType>
-  void get_pointlist_info(const std::vector<PointType> &points, float &xmid,
-                          float &ymid, float &zmid, float &width, float &height,
-                          float &depth) {
-    xmid = ymid = zmid = width = height = depth = 0.0;
-    if (points.size()) {
-      float xmin, ymin, zmin, xmax, ymax, zmax;
-      float xsum = 0, ysum = 0, zsum = 0;
-      bool first = true;
-      for (const auto &point : points) {
-        const float x(point[0]), y(point[1]), z(point[2]);
-        xsum += x;
-        ysum += y;
-        zsum += z;
-
-        if (first) {
-          xmin = xmax = x;
-          ymin = ymax = y;
-          zmin = zmax = z;
-          first = false;
-        } else {
-          xmin = min(xmin, x);
-          xmax = max(xmax, x);
-          ymin = min(ymin, y);
-          ymax = max(ymax, y);
-          zmin = min(zmin, z);
-          zmax = max(zmax, z);
-        }
-      }
-
-      xmid = xsum / points.size();
-      ymid = ysum / points.size();
-      zmid = zsum / points.size();
-      width = xmax - xmin;
-      height = ymax - ymin;
-      depth = zmax - zmin;
-    }
-  }
-
-  template <typename PointType>
-  bool is_mean_centered(const std::vector<PointType> &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    std::cerr << "DEBUG: is_mean_centered midpoint: " << xmid << ", " << ymid
-              << ", " << zmid << std::endl;
-    auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
-    return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
-  }
-
-  template <typename PointType>
-  bool has_nonincreasing_extents(const std::vector<PointType> &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    bool result = ((w >= h) && (h >= d) && (d > 0));
-    return result;
-  }
-
-  float find_max_radius(const SphereList &spheres) {
-    float result = 0.0;
-    for (const auto &point : spheres) {
-      result = max(result, point[3]);
-    }
-    return result;
-  }
-
-  bool is_non_null_transform(Transform &a) {
-    // WEAK!
-    int low_row = a.getlowbound(1);
-    int high_row = a.gethighbound(1);
-    int low_col = a.getlowbound(2);
-    int high_col = a.gethighbound(2);
-    bool result = (((high_row - low_row) == 2) && ((high_col - low_col) == 2));
-    if (result) {
-      result = false;
-      for (int r = low_row; !result && (r <= high_row); r++) {
-        ap::raw_vector<double> row_v = a.getrow(r, low_col, high_col);
-        double *curr_col = row_v.GetData();
-        for (int icol = low_col; !result && (icol <= high_col); ++icol) {
-          result = (*curr_col != 0.0);
-          curr_col++;
-        }
+bool coords_match(const mol::AtomVector &atoms, const SphereList &centers,
+                  unsigned int count) {
+  // cout << "coords_match? " << endl
+  //      << "  # atoms:    " << atoms.size() << endl
+  //      << "  # centers:   " << centers.size() << endl
+  //      << "  # to check: " << count << endl;
+  if ((atoms.size() >= count) && (centers.size() >= count)) {
+    for (int i = count - 1; i >= 0; --i) {
+      const mol::Atom &a(atoms[i]);
+      const auto &p(centers[i]);
+      const mol::Position &pos(a.pos());
+      if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
+        return false;
       }
     }
-    return result;
+    return true;
   }
-};
+  return false;
+}
+
+template <typename PointType>
+void get_pointlist_info(const std::vector<PointType> &points, float &xmid,
+                        float &ymid, float &zmid, float &width, float &height,
+                        float &depth) {
+  xmid = ymid = zmid = width = height = depth = 0.0;
+  if (points.size()) {
+    float xmin, ymin, zmin, xmax, ymax, zmax;
+    float xsum = 0, ysum = 0, zsum = 0;
+    bool first = true;
+    for (const auto &point : points) {
+      const float x(point[0]), y(point[1]), z(point[2]);
+      xsum += x;
+      ysum += y;
+      zsum += z;
+
+      if (first) {
+        xmin = xmax = x;
+        ymin = ymax = y;
+        zmin = zmax = z;
+        first = false;
+      } else {
+        xmin = min(xmin, x);
+        xmax = max(xmax, x);
+        ymin = min(ymin, y);
+        ymax = max(ymax, y);
+        zmin = min(zmin, z);
+        zmax = max(zmax, z);
+      }
+    }
+
+    xmid = xsum / points.size();
+    ymid = ysum / points.size();
+    zmid = zsum / points.size();
+    width = xmax - xmin;
+    height = ymax - ymin;
+    depth = zmax - zmin;
+  }
+}
+
+template <typename PointType>
+bool is_mean_centered(const std::vector<PointType> &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  std::cerr << "DEBUG: is_mean_centered midpoint: " << xmid << ", " << ymid
+            << ", " << zmid << std::endl;
+  auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
+  return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
+}
+
+template <typename PointType>
+bool has_nonincreasing_extents(const std::vector<PointType> &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  bool result = ((w >= h) && (h >= d) && (d > 0));
+  return result;
+}
+
+float find_max_radius(const SphereList &spheres) {
+  float result = 0.0;
+  for (const auto &point : spheres) {
+    result = max(result, point[3]);
+  }
+  return result;
+}
+
+bool is_non_null_transform(Transform &a) {
+  // WEAK!
+  int low_row = a.getlowbound(1);
+  int high_row = a.gethighbound(1);
+  int low_col = a.getlowbound(2);
+  int high_col = a.gethighbound(2);
+  bool result = (((high_row - low_row) == 2) && ((high_col - low_col) == 2));
+  if (result) {
+    result = false;
+    for (int r = low_row; !result && (r <= high_row); r++) {
+      ap::raw_vector<double> row_v = a.getrow(r, low_col, high_col);
+      double *curr_col = row_v.GetData();
+      for (int icol = low_col; !result && (icol <= high_col); ++icol) {
+        result = (*curr_col != 0.0);
+        curr_col++;
+      }
+    }
+  }
+  return result;
+}
 } // namespace
 
 TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   // This setup is performed separately for each section.
-  TestFixture fixture;
-  std::unique_ptr<TCAxisAligner> aligner(fixture.new_aligner());
+  std::unique_ptr<TCAxisAligner> aligner(new_aligner());
   mol::AtomVector atoms;
   SphereList centers;
 
@@ -338,14 +290,14 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   SECTION("Get atom coords from a vector of heavy atoms") {
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE(atoms.size() > num_heavies);
     REQUIRE(num_heavies > 0);
-    REQUIRE(fixture.coords_match(atoms, centers, num_heavies));
+    REQUIRE(coords_match(atoms, centers, num_heavies));
 
     aligner->tc_get_atom_points(atoms, centers, true);
-    REQUIRE(fixture.coords_match(atoms, centers, atoms.size()));
+    REQUIRE(coords_match(atoms, centers, atoms.size()));
   }
 
   SECTION("Get the mean center of an empty list of points") {
@@ -362,7 +314,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     unsigned int num_heavies;
     Point3D center;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     aligner->tc_get_mean_center(centers, center);
     REQUIRE(center.size() == 3);
@@ -388,15 +340,15 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
     // TODO:  create a set of atoms w. known positions and
     // easily verified extents.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE((size_t)num_heavies == centers.size());
     aligner->tc_mean_center_points(centers);
     REQUIRE((size_t)num_heavies == centers.size());
-    REQUIRE(fixture.is_mean_centered(centers));
+    REQUIRE(is_mean_centered(centers));
 
     float xmid, ymid, zmid, width, height, depth;
-    fixture.get_pointlist_info(centers, xmid, ymid, zmid, width, height, depth);
+    get_pointlist_info(centers, xmid, ymid, zmid, width, height, depth);
     REQUIRE_THAT(width, Catch::Matchers::WithinAbs(9.9782, 0.00001));
     REQUIRE_THAT(height, Catch::Matchers::WithinAbs(4.4967, 0.00001));
     REQUIRE_THAT(depth, Catch::Matchers::WithinAbs(6.8714, 0.00001));
@@ -413,7 +365,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   SECTION("Get mean-centered cloud -- non-empty") {
     unsigned int num_heavies;
     Point3DList cloud;
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE(!centers.empty());
     REQUIRE(centers.size() == num_heavies);
@@ -424,17 +376,15 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE(!cloud.empty());
 
     float xmid, ymid, zmid, pwidth, pheight, pdepth;
-    fixture.get_pointlist_info(centers, xmid, ymid, zmid, pwidth, pheight,
-                               pdepth);
-    REQUIRE(fixture.is_mean_centered(centers));
+    get_pointlist_info(centers, xmid, ymid, zmid, pwidth, pheight, pdepth);
+    REQUIRE(is_mean_centered(centers));
     REQUIRE_THAT(pwidth, Catch::Matchers::WithinAbs(9.9782, 0.00001));
     REQUIRE_THAT(pheight, Catch::Matchers::WithinAbs(4.4967, 0.00001));
     REQUIRE_THAT(pdepth, Catch::Matchers::WithinAbs(6.8714, 0.00001));
 
     float cwidth, cheight, cdepth;
-    fixture.get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight,
-                               cdepth);
-    float dmax = 2.0 * fixture.find_max_radius(centers);
+    get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight, cdepth);
+    float dmax = 2.0 * find_max_radius(centers);
 
     // Hardwired badness: max radius of all atoms in create_sample_atoms should
     // be that of sulfur.
@@ -456,7 +406,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     aligner->tc_mean_center_points(centers);
     aligner->tc_get_mean_centered_cloud(centers, cloud);
@@ -464,9 +414,9 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     // Not sure how to test this.  Just confirm it's a 3x3 matrix
     // with non-empty cells?
     Transform transform;
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
   }
 
   SECTION("Untranslate centers") {
@@ -503,14 +453,14 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE_THROWS_AS(aligner->tc_find_axis_align_transform(cloud, transform),
                       invalid_argument);
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     aligner->tc_mean_center_points(centers);
     aligner->tc_get_mean_centered_cloud(centers, cloud);
 
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
 
     // Verify no crash on an empty point list.
     centers.clear();
@@ -518,13 +468,13 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE(centers.empty());
 
     aligner->tc_get_atom_points(atoms, centers, false);
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     aligner->tc_transform_points(centers, transform);
     REQUIRE(centers.size() == num_heavies);
 
     // Transform should merely rotate the points -- no mean-centering.
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Update atom coords") {
@@ -533,7 +483,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
     // Ensure correct copying of transformed point coords to
     // corresponding atom coords.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
 
     // Point and atom lists of different size?  This should fail.
     aligner->tc_get_atom_points(atoms, centers, false);
@@ -567,16 +517,16 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
-    REQUIRE(!fixture.is_mean_centered(centers));
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!is_mean_centered(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(atoms);
     aligner->tc_get_atom_points(atoms, centers, false);
-    REQUIRE(fixture.is_mean_centered(centers));
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(is_mean_centered(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Align mol to axes") {
@@ -590,20 +540,20 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(!fixture.is_mean_centered(centers));
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!is_mean_centered(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(fixture.is_mean_centered(centers));
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(is_mean_centered(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Align to axes - mol only") {
-    std::unique_ptr<TCAxisAligner> aligner(fixture.new_aligner_ac_only());
+    std::unique_ptr<TCAxisAligner> aligner(new_aligner_ac_only());
     mol::Mol mol;
 
     // No crash on empty:
@@ -614,18 +564,18 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(!fixture.is_mean_centered(centers));
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!is_mean_centered(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     // TODO:  Check that align_to_axes with atom-centers-only produces
     // different results than without atom-centers-only.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(fixture.is_mean_centered(centers));
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(is_mean_centered(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Align hydrogens") {
@@ -635,20 +585,19 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
     float x, y, z, w, h, d;
 
-    mol::Mol mol(
-        {.atoms = {
-             fixture.atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
-             fixture.atom("H", 0.0, 0.0, 1.0),
-             fixture.atom("C", 0.0, 0.0, 2.0),
-             fixture.atom("H", 0.0, 0.0, 3.0),
-             fixture.atom("C", 0.0, 0.0, 4.0),
-             fixture.atom("H", 0.0, 0.0, 5.0),
-             fixture.atom("C", 0.0, 0.0, 6.0),
-             fixture.atom("H", 0.0, 0.0, 7.0),
-         }});
+    mol::Mol mol({.atoms = {
+                      atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
+                      atom("H", 0.0, 0.0, 1.0),
+                      atom("C", 0.0, 0.0, 2.0),
+                      atom("H", 0.0, 0.0, 3.0),
+                      atom("C", 0.0, 0.0, 4.0),
+                      atom("H", 0.0, 0.0, 5.0),
+                      atom("C", 0.0, 0.0, 6.0),
+                      atom("H", 0.0, 0.0, 7.0),
+                  }});
 
     aligner->tc_get_atom_points(mol.atoms(), centers, true);
-    fixture.get_pointlist_info(centers, x, y, z, w, h, d);
+    get_pointlist_info(centers, x, y, z, w, h, d);
 
     REQUIRE_THAT(w, Catch::Matchers::WithinAbs(0.0f, 0.00001));
     REQUIRE_THAT(h, Catch::Matchers::WithinAbs(0.0f, 0.00001));
@@ -657,7 +606,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), centers, true);
 
-    fixture.get_pointlist_info(centers, x, y, z, w, h, d);
+    get_pointlist_info(centers, x, y, z, w, h, d);
 
     // The slope from point to point should be consistent.
     const float dx_dy = w / h;
@@ -707,14 +656,13 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 }
 
 namespace {
-int benchmark_align_to_axes(const TestFixture &fixture,
-                            std::shared_ptr<TCAxisAligner> aligner) {
+int benchmark_align_to_axes(std::shared_ptr<TCAxisAligner> aligner) {
   mol::Mol mol;
   SphereList centers;
   Point3DList cloud;
   unsigned int num_heavies;
 
-  fixture.create_sample_mol(mol, num_heavies);
+  create_sample_mol(mol, num_heavies);
   aligner->tc_get_atom_points(mol.atoms(), centers, false);
 
   // TODO:  Check that the hydrogens are also transformed.
@@ -725,22 +673,16 @@ int benchmark_align_to_axes(const TestFixture &fixture,
 
 TEST_CASE("mesaac::shape::AxisAligner Benchmarks",
           "[mesaac][mesaac_benchmark]") {
-  TestFixture fixture;
-
   BENCHMARK_ADVANCED("Point cloud alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAligner> aligner(fixture.new_aligner());
-    meter.measure([fixture, aligner] {
-      return benchmark_align_to_axes(fixture, aligner);
-    });
+    std::shared_ptr<TCAxisAligner> aligner(new_aligner());
+    meter.measure([aligner] { return benchmark_align_to_axes(aligner); });
   };
 
   BENCHMARK_ADVANCED("Atom center alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAligner> ac_aligner(fixture.new_aligner_ac_only());
-    meter.measure([fixture, ac_aligner] {
-      return benchmark_align_to_axes(fixture, ac_aligner);
-    });
+    std::shared_ptr<TCAxisAligner> ac_aligner(new_aligner_ac_only());
+    meter.measure([ac_aligner] { return benchmark_align_to_axes(ac_aligner); });
   };
 }
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
@@ -9,8 +9,8 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <filesystem>
+#include <format>
 #include <fstream>
-#include <iostream>
 
 #include "mesaac_mol/element_info.hpp"
 #include "mesaac_shape/axis_aligner.hpp"
@@ -23,8 +23,7 @@ namespace {
 
 // T[est]C[ase]AxisAligner exposes protected AxisAligner methods,
 // to ease test case definitions.
-class TCAxisAligner : public AxisAligner {
-public:
+struct TCAxisAligner : public AxisAligner {
   TCAxisAligner(Point3DList &points, float atom_scale, bool atom_centers_only)
       : AxisAligner(points, atom_scale, atom_centers_only) {}
 
@@ -73,9 +72,8 @@ void read_test_points(const filesystem::path &pathname, Point3DList &points) {
   points.clear();
   ifstream inf(full_path);
   if (!inf) {
-    ostringstream msg;
-    msg << "Could not open " << pathname << " for reading." << endl;
-    throw std::runtime_error(msg.str());
+    throw runtime_error(
+        format("Could not open {} for reading.", string(pathname)));
   }
   float x, y, z;
   while (inf >> x >> y >> z) {
@@ -228,8 +226,6 @@ template <typename PointType>
 bool is_mean_centered(const std::vector<PointType> &points) {
   float xmid, ymid, zmid, w, h, d;
   get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-  std::cerr << "DEBUG: is_mean_centered midpoint: " << xmid << ", " << ymid
-            << ", " << zmid << std::endl;
   auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
   return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
 }

--- a/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
@@ -7,8 +7,8 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <filesystem>
+#include <format>
 #include <fstream>
-#include <iostream>
 
 #include "mesaac_mol/element_info.hpp"
 #include "mesaac_shape/axis_aligner_eigen.hpp"
@@ -18,8 +18,7 @@ using namespace std;
 namespace mesaac::shape {
 
 namespace {
-class TCAxisAlignerEigen : public AxisAlignerEigen {
-public:
+struct TCAxisAlignerEigen : public AxisAlignerEigen {
   TCAxisAlignerEigen(Point3DList &points, float atom_scale,
                      bool atom_centers_only)
       : AxisAlignerEigen(points, atom_scale, atom_centers_only) {}
@@ -60,193 +59,188 @@ public:
   }
 };
 
-struct TestFixture {
-  void read_test_points(filesystem::path pathname, Point3DList &points) {
-    const filesystem::path test_data_dir(TEST_DATA_DIR);
-    const auto data_dir(test_data_dir / "hammersley/");
-    const auto full_path(data_dir / pathname);
-    points.clear();
-    ifstream inf(full_path);
-    if (!inf) {
-      ostringstream msg;
-      msg << "Could not open " << pathname << " for reading." << endl;
-      FAIL(msg.str());
-    }
-    float x, y, z;
-    while (inf >> x >> y >> z) {
-      points.push_back({x, y, z});
-    }
-    inf.close();
+// TODO DRY
+void read_test_points(filesystem::path pathname, Point3DList &points) {
+  const filesystem::path test_data_dir(TEST_DATA_DIR);
+  const auto data_dir(test_data_dir / "hammersley/");
+  const auto full_path(data_dir / pathname);
+  points.clear();
+  ifstream inf(full_path);
+  if (!inf) {
+    throw runtime_error(
+        format("Could not open {} for reading.", string(pathname)));
   }
-
-  std::unique_ptr<TCAxisAlignerEigen> new_aligner() {
-    Point3DList sphere;
-    float atom_scale = 1.0;
-
-    // Assume we will be run in a location fixed relative to
-    // the data files.
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, false);
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    points.push_back({x, y, z});
   }
+  inf.close();
+}
 
-  std::unique_ptr<TCAxisAlignerEigen> new_aligner_ac_only() {
-    Point3DList sphere;
-    float atom_scale = 1.0;
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, true);
+std::unique_ptr<TCAxisAlignerEigen> new_aligner() {
+  Point3DList sphere;
+  float atom_scale = 1.0;
+
+  // Assume we will be run in a location fixed relative to
+  // the data files.
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, false);
+}
+
+std::unique_ptr<TCAxisAlignerEigen> new_aligner_ac_only() {
+  Point3DList sphere;
+  float atom_scale = 1.0;
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, true);
+}
+
+mol::Atom atom(string symbol, float x, float y, float z) {
+  const unsigned char atomic_num(mol::get_atomic_num(symbol));
+  return {{atomic_num, {x, y, z}}};
+} // namespace shape_eigen
+
+void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) {
+  // Coordinates taken from first cox2_3d conformer.
+  mol::AtomVector atoms{
+      atom("C", 27.7051, 22.0403, 17.0243),
+      atom("N", 26.4399, 22.0976, 16.4318),
+      atom("C", 25.5381, 21.4424, 17.2831),
+      atom("C", 26.2525, 20.9753, 18.3748),
+      atom("C", 27.5943, 21.3608, 18.2218),
+      atom("C", 24.0821, 21.3670, 17.1082),
+      atom("C", 26.1324, 22.6824, 15.1634),
+      atom("C", 23.4105, 22.2668, 16.2675),
+      atom("C", 22.0220, 22.2007, 16.1197),
+      atom("C", 21.2976, 21.2409, 16.8307),
+      atom("C", 21.9509, 20.3402, 17.6750),
+      atom("C", 23.3399, 20.4115, 17.8175),
+      atom("C", 26.3695, 24.0457, 14.9358),
+      atom("C", 26.0627, 24.6119, 13.6959),
+      atom("C", 25.5236, 23.8179, 12.6910),
+      atom("C", 25.2821, 22.4660, 12.9010),
+      atom("C", 25.5848, 21.8942, 14.1391),
+      atom("F", 25.2311, 24.3643, 11.5034),
+      atom("C", 28.9655, 22.5443, 16.4025),
+      atom("S", 19.5328, 21.1457, 16.6315),
+      atom("O", 19.0413, 22.4851, 16.3229),
+      atom("O", 18.9873, 20.4577, 17.7975),
+      atom("C", 19.3258, 20.1152, 15.2035),
+      atom("H", 25.8309, 20.4354, 19.2156),
+      atom("H", 28.4100, 21.1477, 18.9041),
+      atom("H", 23.9630, 23.0298, 15.7210),
+      atom("H", 21.5209, 22.9035, 15.4575),
+      atom("H", 21.3956, 19.5863, 18.2287),
+      atom("H", 23.8404, 19.7079, 18.4815),
+      atom("H", 26.7480, 24.6961, 15.7203),
+      atom("H", 26.2341, 25.6696, 13.5167),
+      atom("H", 24.8658, 21.8592, 12.1019),
+      atom("H", 25.4187, 20.8273, 14.2701),
+      atom("H", 29.8338, 22.0387, 16.8401),
+      atom("H", 29.0870, 23.6157, 16.5858),
+      atom("H", 28.9947, 22.3510, 15.3261),
+      atom("H", 18.2555, 20.0118, 15.0126),
+      atom("H", 19.7633, 19.1356, 15.4046),
+      atom("H", 19.8115, 20.5898, 14.3489),
+  };
+  mol = mol::Mol({.atoms = atoms});
+  num_heavies = 23;
+}
+
+void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
+  mol::Mol mol;
+
+  create_sample_mol(mol, num_heavies);
+  // Take care to deep-copy all of the atom pointers.
+  atoms.clear();
+  const mol::AtomVector &src(mol.atoms());
+  for (const auto src_atom : src) {
+    atoms.push_back(src_atom);
   }
+}
 
-  mol::Atom atom(string symbol, float x, float y, float z) const {
-    const unsigned char atomic_num(mol::get_atomic_num(symbol));
-    return {{atomic_num, {x, y, z}}};
-  } // namespace shape_eigen
-
-  void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) const {
-    // Coordinates taken from first cox2_3d conformer.
-    mol::AtomVector atoms{
-        atom("C", 27.7051, 22.0403, 17.0243),
-        atom("N", 26.4399, 22.0976, 16.4318),
-        atom("C", 25.5381, 21.4424, 17.2831),
-        atom("C", 26.2525, 20.9753, 18.3748),
-        atom("C", 27.5943, 21.3608, 18.2218),
-        atom("C", 24.0821, 21.3670, 17.1082),
-        atom("C", 26.1324, 22.6824, 15.1634),
-        atom("C", 23.4105, 22.2668, 16.2675),
-        atom("C", 22.0220, 22.2007, 16.1197),
-        atom("C", 21.2976, 21.2409, 16.8307),
-        atom("C", 21.9509, 20.3402, 17.6750),
-        atom("C", 23.3399, 20.4115, 17.8175),
-        atom("C", 26.3695, 24.0457, 14.9358),
-        atom("C", 26.0627, 24.6119, 13.6959),
-        atom("C", 25.5236, 23.8179, 12.6910),
-        atom("C", 25.2821, 22.4660, 12.9010),
-        atom("C", 25.5848, 21.8942, 14.1391),
-        atom("F", 25.2311, 24.3643, 11.5034),
-        atom("C", 28.9655, 22.5443, 16.4025),
-        atom("S", 19.5328, 21.1457, 16.6315),
-        atom("O", 19.0413, 22.4851, 16.3229),
-        atom("O", 18.9873, 20.4577, 17.7975),
-        atom("C", 19.3258, 20.1152, 15.2035),
-        atom("H", 25.8309, 20.4354, 19.2156),
-        atom("H", 28.4100, 21.1477, 18.9041),
-        atom("H", 23.9630, 23.0298, 15.7210),
-        atom("H", 21.5209, 22.9035, 15.4575),
-        atom("H", 21.3956, 19.5863, 18.2287),
-        atom("H", 23.8404, 19.7079, 18.4815),
-        atom("H", 26.7480, 24.6961, 15.7203),
-        atom("H", 26.2341, 25.6696, 13.5167),
-        atom("H", 24.8658, 21.8592, 12.1019),
-        atom("H", 25.4187, 20.8273, 14.2701),
-        atom("H", 29.8338, 22.0387, 16.8401),
-        atom("H", 29.0870, 23.6157, 16.5858),
-        atom("H", 28.9947, 22.3510, 15.3261),
-        atom("H", 18.2555, 20.0118, 15.0126),
-        atom("H", 19.7633, 19.1356, 15.4046),
-        atom("H", 19.8115, 20.5898, 14.3489),
-    };
-    mol = mol::Mol({.atoms = atoms});
-    num_heavies = 23;
-  }
-
-  void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
-    mol::Mol mol;
-
-    create_sample_mol(mol, num_heavies);
-    // Take care to deep-copy all of the atom pointers.
-    atoms.clear();
-    const mol::AtomVector &src(mol.atoms());
-    for (const auto src_atom : src) {
-      atoms.push_back(src_atom);
-    }
-  }
-
-  bool coords_match(const mol::AtomVector &atoms, const SphereList &centers,
-                    unsigned int count) {
-    if ((atoms.size() >= count) && (centers.size() >= count)) {
-      for (int i = count - 1; i >= 0; --i) {
-        const mol::Atom &atom(atoms[i]);
-        const Sphere &p(centers[i]);
-        const mol::Position &pos(atom.pos());
-        if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
-          return false;
-        }
+bool coords_match(const mol::AtomVector &atoms, const SphereList &centers,
+                  unsigned int count) {
+  if ((atoms.size() >= count) && (centers.size() >= count)) {
+    for (int i = count - 1; i >= 0; --i) {
+      const mol::Atom &atom(atoms[i]);
+      const Sphere &p(centers[i]);
+      const mol::Position &pos(atom.pos());
+      if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
+        return false;
       }
-      return true;
     }
-    return false;
+    return true;
   }
+  return false;
+}
 
-  template <typename PointType>
-  void get_pointlist_info(const std::vector<PointType> &points, float &xmid,
-                          float &ymid, float &zmid, float &width, float &height,
-                          float &depth) {
-    xmid = ymid = zmid = width = height = depth = 0.0;
-    if (points.size()) {
-      float xmin, ymin, zmin, xmax, ymax, zmax;
-      float xsum = 0, ysum = 0, zsum = 0;
-      bool first = true;
-      for (const auto &point : points) {
-        const float x(point[0]), y(point[1]), z(point[2]);
-        xsum += x;
-        ysum += y;
-        zsum += z;
-
-        if (first) {
-          xmin = xmax = x;
-          ymin = ymax = y;
-          zmin = zmax = z;
-          first = false;
-        } else {
-          xmin = min(xmin, x);
-          xmax = max(xmax, x);
-          ymin = min(ymin, y);
-          ymax = max(ymax, y);
-          zmin = min(zmin, z);
-          zmax = max(zmax, z);
-        }
-      }
-
-      xmid = xsum / points.size();
-      ymid = ysum / points.size();
-      zmid = zsum / points.size();
-      width = xmax - xmin;
-      height = ymax - ymin;
-      depth = zmax - zmin;
-    }
-  }
-
-  template <typename PointType>
-  bool is_mean_centered(const std::vector<PointType> &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    std::cerr << "DEBUG: is_mean_centered midpoint: " << xmid << ", " << ymid
-              << ", " << zmid << std::endl;
-    auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
-    return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
-  }
-
-  template <typename PointType>
-  bool has_nonincreasing_extents(const std::vector<PointType> &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    bool result = ((w >= h) && (h >= d) && (d > 0));
-    return result;
-  }
-
-  float find_max_radius(const SphereList &points) {
-    float result = 0.0;
+template <typename PointType>
+void get_pointlist_info(const std::vector<PointType> &points, float &xmid,
+                        float &ymid, float &zmid, float &width, float &height,
+                        float &depth) {
+  xmid = ymid = zmid = width = height = depth = 0.0;
+  if (points.size()) {
+    float xmin, ymin, zmin, xmax, ymax, zmax;
+    float xsum = 0, ysum = 0, zsum = 0;
+    bool first = true;
     for (const auto &point : points) {
-      result = max(result, point[3]);
-    }
-    return result;
-  }
+      const float x(point[0]), y(point[1]), z(point[2]);
+      xsum += x;
+      ysum += y;
+      zsum += z;
 
-  bool is_non_null_transform(Transform &atom) { return !atom.isZero(); }
-};
+      if (first) {
+        xmin = xmax = x;
+        ymin = ymax = y;
+        zmin = zmax = z;
+        first = false;
+      } else {
+        xmin = min(xmin, x);
+        xmax = max(xmax, x);
+        ymin = min(ymin, y);
+        ymax = max(ymax, y);
+        zmin = min(zmin, z);
+        zmax = max(zmax, z);
+      }
+    }
+
+    xmid = xsum / points.size();
+    ymid = ysum / points.size();
+    zmid = zsum / points.size();
+    width = xmax - xmin;
+    height = ymax - ymin;
+    depth = zmax - zmin;
+  }
+}
+
+template <typename PointType>
+bool is_mean_centered(const std::vector<PointType> &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
+  return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
+}
+
+template <typename PointType>
+bool has_nonincreasing_extents(const std::vector<PointType> &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  bool result = ((w >= h) && (h >= d) && (d > 0));
+  return result;
+}
+
+float find_max_radius(const SphereList &points) {
+  float result = 0.0;
+  for (const auto &point : points) {
+    result = max(result, point[3]);
+  }
+  return result;
+}
+
+bool is_non_null_transform(Transform &atom) { return !atom.isZero(); }
 
 TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
-  TestFixture fixture;
-  std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
+  std::unique_ptr<TCAxisAlignerEigen> aligner(new_aligner());
   mol::AtomVector atoms;
   SphereList centers;
 
@@ -263,14 +257,14 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
   SECTION("Get atom coords from a vector of heavy atoms") {
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE(atoms.size() > num_heavies);
     REQUIRE(num_heavies > 0);
-    REQUIRE(fixture.coords_match(atoms, centers, num_heavies));
+    REQUIRE(coords_match(atoms, centers, num_heavies));
 
     aligner->tc_get_atom_points(atoms, centers, true);
-    REQUIRE(fixture.coords_match(atoms, centers, atoms.size()));
+    REQUIRE(coords_match(atoms, centers, atoms.size()));
   }
 
   SECTION("Get the mean center of an empty list of points") {
@@ -284,7 +278,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     unsigned int num_heavies;
     Point3D center;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     aligner->tc_get_mean_center(centers, center);
     // FRAGILE
@@ -306,14 +300,14 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 
     // TODO:  create a set of atoms w. known positions and
     // easily verified extents.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE(centers.size() == (size_t)num_heavies);
     aligner->tc_mean_center_points(centers);
-    REQUIRE(fixture.is_mean_centered(centers));
+    REQUIRE(is_mean_centered(centers));
 
     float xmid, ymid, zmid, width, height, depth;
-    fixture.get_pointlist_info(centers, xmid, ymid, zmid, width, height, depth);
+    get_pointlist_info(centers, xmid, ymid, zmid, width, height, depth);
     REQUIRE_THAT(9.9782, Catch::Matchers::WithinAbs(width, 0.00001));
     REQUIRE_THAT(4.4967, Catch::Matchers::WithinAbs(height, 0.00001));
     REQUIRE_THAT(6.8714, Catch::Matchers::WithinAbs(depth, 0.00001));
@@ -331,7 +325,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     REQUIRE(centers.size() > 0);
     REQUIRE(centers.size() == (size_t)num_heavies);
@@ -340,17 +334,15 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE(cloud.size() > 0);
 
     float xmid, ymid, zmid, pwidth, pheight, pdepth;
-    fixture.get_pointlist_info(centers, xmid, ymid, zmid, pwidth, pheight,
-                               pdepth);
-    REQUIRE(fixture.is_mean_centered(centers));
+    get_pointlist_info(centers, xmid, ymid, zmid, pwidth, pheight, pdepth);
+    REQUIRE(is_mean_centered(centers));
     REQUIRE_THAT(9.9782, Catch::Matchers::WithinAbs(pwidth, 0.00001));
     REQUIRE_THAT(4.4967, Catch::Matchers::WithinAbs(pheight, 0.00001));
     REQUIRE_THAT(6.8714, Catch::Matchers::WithinAbs(pdepth, 0.00001));
 
     float cwidth, cheight, cdepth;
-    fixture.get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight,
-                               cdepth);
-    float dmax = 2.0 * fixture.find_max_radius(centers);
+    get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight, cdepth);
+    float dmax = 2.0 * find_max_radius(centers);
     // Bench-check:  max radius should be 1.8, for sulfur.
     REQUIRE(dmax == 3.60f);
 
@@ -369,7 +361,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     aligner->tc_mean_center_points(centers);
     aligner->tc_get_mean_centered_cloud(centers, cloud);
@@ -377,10 +369,10 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     // Not sure how to test this.  Just confirm it's a 3x3 matrix
     // with non-empty cells?
     Transform transform = Transform::Zero();
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
 
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
   }
 
   SECTION("Untranslate points") {
@@ -417,14 +409,14 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE_THROWS_AS(aligner->tc_find_axis_align_transform(cloud, transform),
                       invalid_argument);
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
     aligner->tc_mean_center_points(centers);
     aligner->tc_get_mean_centered_cloud(centers, cloud);
 
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
 
     // Verify no crash on an empty point list.
     centers.clear();
@@ -432,13 +424,13 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE(centers.empty());
 
     aligner->tc_get_atom_points(atoms, centers, false);
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     aligner->tc_transform_points(centers, transform);
     REQUIRE(centers.size() == (size_t)num_heavies);
 
     // Transform should merely rotate the centers -- no mean-centering.
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Update atom coords") {
@@ -447,7 +439,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 
     // Ensure correct copying of transformed point coords to
     // corresponding atom coords.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
 
     // Point and atom lists of different size?  This should fail.
     aligner->tc_get_atom_points(atoms, centers, false);
@@ -481,16 +473,16 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, centers, false);
-    REQUIRE(!fixture.is_mean_centered(centers));
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!is_mean_centered(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(atoms);
     aligner->tc_get_atom_points(atoms, centers, false);
-    REQUIRE(fixture.is_mean_centered(centers));
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(is_mean_centered(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Align mol to axes") {
@@ -504,16 +496,16 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(!fixture.is_mean_centered(centers));
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!is_mean_centered(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(fixture.is_mean_centered(centers));
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(is_mean_centered(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Point cloud alignment") {
@@ -527,18 +519,18 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     Point3DList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(!fixture.is_mean_centered(centers));
-    REQUIRE(!fixture.has_nonincreasing_extents(centers));
+    REQUIRE(!is_mean_centered(centers));
+    REQUIRE(!has_nonincreasing_extents(centers));
 
     // TODO:  Check that the hydrogens are also transformed.
     // TODO:  Check that align_to_axes with atom-centers-only produces
     // different results than without atom-centers-only.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), centers, false);
-    REQUIRE(fixture.is_mean_centered(centers));
-    REQUIRE(fixture.has_nonincreasing_extents(centers));
+    REQUIRE(is_mean_centered(centers));
+    REQUIRE(has_nonincreasing_extents(centers));
   }
 
   SECTION("Align hydrogens") {
@@ -547,20 +539,19 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     // the X axis.
     float x, y, z, w, h, d;
 
-    mol::Mol mol(
-        {.atoms = {
-             fixture.atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
-             fixture.atom("H", 0.0, 0.0, 1.0),
-             fixture.atom("C", 0.0, 0.0, 2.0),
-             fixture.atom("H", 0.0, 0.0, 3.0),
-             fixture.atom("C", 0.0, 0.0, 4.0),
-             fixture.atom("H", 0.0, 0.0, 5.0),
-             fixture.atom("C", 0.0, 0.0, 6.0),
-             fixture.atom("H", 0.0, 0.0, 7.0),
-         }});
+    mol::Mol mol({.atoms = {
+                      atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
+                      atom("H", 0.0, 0.0, 1.0),
+                      atom("C", 0.0, 0.0, 2.0),
+                      atom("H", 0.0, 0.0, 3.0),
+                      atom("C", 0.0, 0.0, 4.0),
+                      atom("H", 0.0, 0.0, 5.0),
+                      atom("C", 0.0, 0.0, 6.0),
+                      atom("H", 0.0, 0.0, 7.0),
+                  }});
 
     aligner->tc_get_atom_points(mol.atoms(), centers, true);
-    fixture.get_pointlist_info(centers, x, y, z, w, h, d);
+    get_pointlist_info(centers, x, y, z, w, h, d);
     REQUIRE(w == 0.0f);
     REQUIRE(h == 0.0f);
     REQUIRE(d == 7.0f);
@@ -568,7 +559,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), centers, true);
 
-    fixture.get_pointlist_info(centers, x, y, z, w, h, d);
+    get_pointlist_info(centers, x, y, z, w, h, d);
 
     // The slope from point to point should be consistent.
     const float dx_dy = w / h;
@@ -619,14 +610,13 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 }
 
 namespace {
-int benchmark_align_to_axes(const TestFixture &fixture,
-                            std::shared_ptr<TCAxisAlignerEigen> aligner) {
+int benchmark_align_to_axes(std::shared_ptr<TCAxisAlignerEigen> aligner) {
   mol::Mol mol;
   SphereList centers;
   Point3DList cloud;
   unsigned int num_heavies;
 
-  fixture.create_sample_mol(mol, num_heavies);
+  create_sample_mol(mol, num_heavies);
   aligner->tc_get_atom_points(mol.atoms(), centers, false);
 
   // TODO:  Check that the hydrogens are also transformed.
@@ -639,23 +629,16 @@ int benchmark_align_to_axes(const TestFixture &fixture,
 
 TEST_CASE("mesaac::shape::AxisAlignerEigen Benchmarks",
           "[mesaac][mesaac_benchmark]") {
-  TestFixture fixture;
-
   BENCHMARK_ADVANCED("Point cloud alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
-    meter.measure([fixture, aligner] {
-      return benchmark_align_to_axes(fixture, aligner);
-    });
+    std::shared_ptr<TCAxisAlignerEigen> aligner(new_aligner());
+    meter.measure([aligner] { return benchmark_align_to_axes(aligner); });
   };
 
   BENCHMARK_ADVANCED("Atom center alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAlignerEigen> ac_aligner(
-        fixture.new_aligner_ac_only());
-    meter.measure([fixture, ac_aligner] {
-      return benchmark_align_to_axes(fixture, ac_aligner);
-    });
+    std::shared_ptr<TCAxisAlignerEigen> ac_aligner(new_aligner_ac_only());
+    meter.measure([ac_aligner] { return benchmark_align_to_axes(ac_aligner); });
   };
 }
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
@@ -605,9 +605,9 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 
     const Sphere atom({0, 0, 0, 170.0});
 
-    SphereList mol1{atom};
+    const SphereList mol1{atom};
     // Duplicates, superposed!
-    SphereList mol2{atom, atom};
+    const SphereList mol2{atom, atom};
 
     Point3DList contained1, contained2;
     aligner->tc_get_mean_centered_cloud(mol1, contained1);

--- a/tests/src/lib/mesaac_shape/test_fingerprinter.cpp
+++ b/tests/src/lib/mesaac_shape/test_fingerprinter.cpp
@@ -48,7 +48,7 @@ struct TestFixture {
     BoundingCube bc;
     get_av_bounds(atoms, bc);
     const unsigned int num_points(10240);
-    PointList hamms;
+    Point3DList hamms;
     Hammersley::get_cuboid({.num_points = num_points,
                             .xmin = bc.xmin,
                             .xmax = bc.xmax,

--- a/tests/src/lib/mesaac_shape/test_fingerprinter.cpp
+++ b/tests/src/lib/mesaac_shape/test_fingerprinter.cpp
@@ -17,74 +17,70 @@ struct BoundingCube {
   BoundingCube() { xmin = ymin = zmin = xmax = ymax = zmax = 0.0; }
 };
 
-struct TestFixture {
-  void get_av_bounds(mol::AtomVector &atoms, BoundingCube &b) {
-    bool first = true;
-    for (const auto atom : atoms) {
-      const float r(atom.radius());
-      const auto &pos(atom.pos());
-      float x(pos.x()), y(pos.y()), z(pos.z());
+void get_av_bounds(mol::AtomVector &atoms, BoundingCube &b) {
+  bool first = true;
+  for (const auto atom : atoms) {
+    const float r(atom.radius());
+    const auto &pos(atom.pos());
+    float x(pos.x()), y(pos.y()), z(pos.z());
 
-      if (first) {
-        b.xmin = x - r;
-        b.xmax = x + r;
-        b.ymin = y - r;
-        b.ymax = y + r;
-        b.zmin = z - r;
-        b.zmax = z + r;
-        first = false;
-      } else {
-        b.xmin = min(b.xmin, x - r);
-        b.xmax = max(b.xmax, x + r);
-        b.ymin = min(b.ymin, y - r);
-        b.ymax = max(b.ymax, y + r);
-        b.zmin = min(b.zmin, z - r);
-        b.zmax = max(b.zmax, z + r);
-      }
+    if (first) {
+      b.xmin = x - r;
+      b.xmax = x + r;
+      b.ymin = y - r;
+      b.ymax = y + r;
+      b.zmin = z - r;
+      b.zmax = z + r;
+      first = false;
+    } else {
+      b.xmin = min(b.xmin, x - r);
+      b.xmax = max(b.xmax, x + r);
+      b.ymin = min(b.ymin, y - r);
+      b.ymax = max(b.ymax, y + r);
+      b.zmin = min(b.zmin, z - r);
+      b.zmax = max(b.zmax, z + r);
     }
-  } // namespace mesaac
+  }
+} // namespace mesaac
 
-  void test_for_atom_vector(mol::AtomVector &atoms, bool shouldBeEqual) {
-    BoundingCube bc;
-    get_av_bounds(atoms, bc);
-    const unsigned int num_points(10240);
-    Point3DList hamms;
-    Hammersley::get_cuboid({.num_points = num_points,
-                            .xmin = bc.xmin,
-                            .xmax = bc.xmax,
-                            .ymin = bc.ymin,
-                            .ymax = bc.ymax,
-                            .zmin = bc.zmin,
-                            .zmax = bc.zmax},
-                           hamms);
-    VolBox vb(hamms, 1.0);
+void test_for_atom_vector(mol::AtomVector &atoms, bool shouldBeEqual) {
+  BoundingCube bc;
+  get_av_bounds(atoms, bc);
+  const unsigned int num_points(10240);
+  Point3DList hamms;
+  Hammersley::get_cuboid({.num_points = num_points,
+                          .xmin = bc.xmin,
+                          .xmax = bc.xmax,
+                          .ymin = bc.ymin,
+                          .ymax = bc.ymax,
+                          .zmin = bc.zmin,
+                          .zmax = bc.zmax},
+                         hamms);
+  VolBox vb(hamms, 1.0);
 
-    Fingerprinter fp(vb);
-    ShapeFingerprint sfp;
-    fp.compute(atoms, sfp);
-    REQUIRE((size_t)4 == sfp.size());
-    for (int j = 0; j != (int)sfp.size(); ++j) {
-      Fingerprint &fp(sfp[j]);
-      REQUIRE((size_t)num_points == fp.size());
-      //   cout << fp << endl;
-      if (j > 0) {
-        Fingerprint &prev(sfp[j - 1]);
-        if (shouldBeEqual) {
-          float either = (fp | prev).count();
-          float both = (fp & prev).count();
-          // Allow for small sampling errors.
-          REQUIRE((both / either) >= 0.93);
-        } else {
-          REQUIRE(fp != prev);
-        }
+  Fingerprinter fp(vb);
+  ShapeFingerprint sfp;
+  fp.compute(atoms, sfp);
+  REQUIRE((size_t)4 == sfp.size());
+  for (int j = 0; j != (int)sfp.size(); ++j) {
+    Fingerprint &fp(sfp[j]);
+    REQUIRE((size_t)num_points == fp.size());
+    //   cout << fp << endl;
+    if (j > 0) {
+      Fingerprint &prev(sfp[j - 1]);
+      if (shouldBeEqual) {
+        float either = (fp | prev).count();
+        float both = (fp & prev).count();
+        // Allow for small sampling errors.
+        REQUIRE((both / either) >= 0.93);
+      } else {
+        REQUIRE(fp != prev);
       }
     }
   }
-};
+}
 
 TEST_CASE("mesaac::shape::Fingerprinter", "[mesaac]") {
-  TestFixture fixture;
-
   SECTION("Test Symmetric Atom Vector") {
     // These atoms are regularly spaced in a straight line along x.
     // Their flips should all produce identical fingerprints.
@@ -93,7 +89,7 @@ TEST_CASE("mesaac::shape::Fingerprinter", "[mesaac]") {
       mol::Atom a({.atomic_num = 12, .pos = {i, 0, 0}});
       atoms.push_back(a);
     }
-    fixture.test_for_atom_vector(atoms, true);
+    test_for_atom_vector(atoms, true);
   }
 
   SECTION("Test Asymmetric Atom Vector") {
@@ -107,7 +103,7 @@ TEST_CASE("mesaac::shape::Fingerprinter", "[mesaac]") {
 
       y = -y;
     }
-    fixture.test_for_atom_vector(atoms, false);
+    test_for_atom_vector(atoms, false);
   }
 }
 

--- a/tests/src/lib/mesaac_shape/test_hammersley.cpp
+++ b/tests/src/lib/mesaac_shape/test_hammersley.cpp
@@ -13,7 +13,7 @@ namespace mesaac::shape {
 
 namespace {
 
-void check_max_extents(const PointList &points, float xmin, float xmax,
+void check_max_extents(const Point3DList &points, float xmin, float xmax,
                        float ymin, float ymax, float zmin, float zmax) {
   if (points.size()) {
     float axmin, axmax, aymin, aymax, azmin, azmax;
@@ -46,7 +46,7 @@ TEST_CASE("mesaac::shape::Hammersley - get_ellipsoid", "[mesaac]") {
   const float scale_sqr = scale * scale;
   const float a = 1.0, b = 0.75, c = 0.35; // Arbitrary spheroid squish
 
-  PointList points;
+  Point3DList points;
   Hammersley::get_ellipsoid(
       {.num_points = num_points, .scale = scale, .a = a, .b = b, .c = c},
       points);
@@ -67,7 +67,7 @@ TEST_CASE("mesaac::shape::Hammersley - get_ellipsoid", "[mesaac]") {
 TEST_CASE("mesaac::shape::Hammersley - get_cuboid", "[mesaac]") {
   // Lacking better ideas, how about a semi-random test for a
   // flattish volume?
-  PointList points;
+  Point3DList points;
   float xmin = -2.0, xmax = 3.1, ymin = 5.0, ymax = 10.1, zmin = 0.0,
         zmax = 1.8;
   unsigned int num_points = 10240;

--- a/tests/src/lib/mesaac_shape/test_vol_box.cpp
+++ b/tests/src/lib/mesaac_shape/test_vol_box.cpp
@@ -277,11 +277,9 @@ TEST_CASE("mesaac::shape::VolBox", "[mesaac]") {
 
       const Sphere atom({0, 0, 0, 1.7});
 
-      SphereList mol1, mol2;
-      mol1.push_back(atom);
+      const SphereList mol1{atom};
       // Duplicates, superposed!
-      mol2.push_back(atom);
-      mol2.push_back(atom);
+      const SphereList mol2{atom, atom};
 
       Point3DList sphere;
       fixture.read_default_point_cloud(sphere);


### PR DESCRIPTION
The existing code uses `std::vector` to represent 3-space coordinates for, e.g., Hammersley points, and to represent atom "spheres" – 3-space coordinates with an associated radius. A `std::array` is analogous to a `std::vector` whose extent is known at compile time.  It reduces the potential for runtime bounds errors, and it may offer small performance benefits.  It's a better fit for 3-space coordinates and "spheres", whose container size is known at compile time.