### PR TITLE
Issue 5 async futures

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -97,7 +97,7 @@
     },
     {
       "name": "benchmark",
-      "configurePreset": "default",
+      "configurePreset": "release",
       "output": {
         "outputOnFailure": true
       },

--- a/notes_on_performance_profiling.md
+++ b/notes_on_performance_profiling.md
@@ -1,34 +1,47 @@
-# Motivation
+# Performance Profiling on Ubuntu
 
-When I try to test with code coverage enabled, whether on linux or in a linux docker container, the align_monte executable takes forever to complete. It uses all available cpu while running.
-By contrast, a release build completes quickly.
+## Use the `profile` preset
 
-I'm trying to use `perf` inside a docker container to understand why the `coverage` build behaves so badly. Since `perf` uses system performance counters, its use requires
-root privileges.
-
-Alas, this doesn't work under docker, even when I run an image interactively, connecting as root.
-
-It has been about five years since I last needed to do this...
+To do performance profiling on Ubuntu linux, compile for profiling:
 
 ```shell
-# Run as root:
-
-cd /source
-perf stat build/release/src/cli/align_monte/align_monte tests/data/align_monte/cox2_3d.sd tests/data/hammersley/hamm_spheroid_20k_11rad.txt 1.0
+cmake --preset profile
+cmake --build --preset profile
 ```
 
-It suffices to run the docker image with `--cap-add SYS_ADMIN`:
+## Ensure `perf` is installed
+
+Ensure that the `perf` command is installed, using `sudo apt install` as necessary.
+
+## Enable performance monitoring
+
+You may need to enable performance monitoring, at least until system reboot:
 
 ```shell
-docker run -it --cap-add SYS_ADMIN -u root --rm -v${PWD}:/source -v${DOCKER_BUILD_DIR}:/source/build build_shape_fingerprints bash
-
-# Inside the container:
-cd /source
-perf stat build/coverage/src/cli/align_monte/align_monte tests/data/align_monte/cox2_3d.sd tests/data/hammersley/hamm_spheroid_20k_11rad.txt 1.0
-perf record --call-graph dwarf build/coverage/src/cli/align_monte/align_monte tests/data/align_monte/cox2_3d.sd tests/data/hammersley/hamm_spheroid_20k_11rad.txt 1.0
-perf report
+sudo sysctl kernel.perf_event_paranoid=-1
 ```
 
-Unfortunately, this turns out to be useless because `perf` does not show any symbolic names -- it shows only addresses. Perhaps CMake is stripping executables?
+## Run with perf
 
-I guess it's good enough to know that the `release` build produces fast executables.
+To collect performance data, run the executable of interest via `perf record`.  For example, from the directory containing this markdown document:
+
+```shell
+perf record build/profile/src/cli/align_monte/align_monte tests/data/sd_files/cox2_3d.sd tests/data/hammersley/hamm_spheroid_20k_11rad.txt 1.0
+```
+
+To see the profiling results, run `perf report`.
+
+Here's example output for the `align_monte` invocation, above.
+
+
+```text
+Samples: 65K of event 'cycles:P', Event count (approx.): 66806926982
+Overhead  Command      Shared Object         Symbol
+  72.49%  align_monte  align_monte           [.] void ap::_vadd<double, double>(double*, double const*, int, double)
+  11.80%  align_monte  align_monte           [.] rmatrixqrunpackq(ap::template_2d_array<double, true> const&, int, int, ap::template_1d_arr
+   2.43%  align_monte  align_monte           [.] mesaac::shape::VolBox::set_bits_for_one_sphere_unchecked(std::array<float, 4ul> const&, bo
+   1.19%  align_monte  [unknown]             [k] 0xffffffffa5125027
+   0.91%  align_monte  align_monte           [.] applyreflectionfromtheleft(ap::template_2d_array<double, true>&, double, ap::template_1d_a
+   0.32%  align_monte  align_monte           [.] ap::vmove(double*, double const*, int)
+   ...
+```

--- a/src/cli/align_monte/CMakeLists.txt
+++ b/src/cli/align_monte/CMakeLists.txt
@@ -2,9 +2,6 @@ set(TARGET align_monte)
 
 set(SRC align_monte.cpp mol_aligner.cpp sdf_mol_aligner.cpp)
 
-# Use OpenMP if it is available
-find_package(OpenMP)
-
 add_executable(${TARGET} ${SRC})
 target_compile_features(${TARGET} PUBLIC cxx_std_20)
 target_link_libraries(
@@ -16,9 +13,5 @@ target_link_libraries(
           mesaac_arg_parser
           svd
           ap)
-if(OpenMP_FOUND)
-  target_compile_definitions(${TARGET} PRIVATE HAVE_OPENMP=1)
-  target_link_libraries(${TARGET} PRIVATE OpenMP::OpenMP_CXX)
-endif()
 
 install(TARGETS ${TARGET})

--- a/src/cli/align_monte/mol_aligner.cpp
+++ b/src/cli/align_monte/mol_aligner.cpp
@@ -48,7 +48,7 @@ void add_best_flip_tag(mol::Mol &mol, string measure_name, unsigned int value) {
 void MolAligner::process_ref_molecule(mol::Mol &mol,
                                       shape_defs::BitVector &ref_fp) {
   // coords holds aligned coordinates for all heavy atoms.
-  PointList heavies;
+  shape::PointList heavies;
 
   m_axisAligner.align_to_axes(mol);
   m_axisAligner.get_atom_points(mol.atoms(), heavies, false);
@@ -67,7 +67,7 @@ void MolAligner::process_ref_molecule(mol::Mol &mol,
 void MolAligner::process_one_molecule(mol::Mol &mol) {
   m_axisAligner.align_to_axes(mol);
 
-  PointList heavies;
+  shape::PointList heavies;
   m_axisAligner.get_atom_points(mol.atoms(), heavies, false);
 
   // The last measure wins, flip-wise?
@@ -87,8 +87,10 @@ void MolAligner::process_one_molecule(mol::Mol &mol) {
 }
 
 void MolAligner::compute_best_sphere_fingerprint(
-    const PointList &points, measures::MeasuresBase::Ptr measure,
+    const shape::PointList &points, measures::MeasuresBase::Ptr measure,
     unsigned int &i_best, float &best_measure) {
+      ostringstream outs;
+      outs << "DEBUG: compute_best_sphere_fingerprint" << endl;
   i_best = 0;
   best_measure = 0;
   for (unsigned int iFlip = 0; iFlip != c_flip_matrix_size; iFlip++) {
@@ -98,17 +100,21 @@ void MolAligner::compute_best_sphere_fingerprint(
       i_best = iFlip;
       best_measure = currMeasure;
     }
+      outs << "    Flip " << iFlip << " has value " << currMeasure << endl;
   }
+  outs << "  RESULT: flip " << i_best << " with value " << best_measure << endl;
+  cerr << outs.str();
+
 }
 
-static inline void get_flipped_points(const PointList &points,
+static inline void get_flipped_points(const shape::PointList &points,
                                       const float *flip,
-                                      PointList &flipped_points) {
+                                      shape::PointList &flipped_points) {
   // How to obviate this copying?  It eats 10% of runtime.
   flipped_points = points;
 
-  PointList::iterator iEnd(flipped_points.end());
-  PointList::iterator i;
+  shape::PointList::iterator iEnd(flipped_points.end());
+  shape::PointList::iterator i;
   for (i = flipped_points.begin(); i != iEnd; ++i) {
     shape::Point &p(*i);
     p[0] *= flip[0];
@@ -118,14 +124,16 @@ static inline void get_flipped_points(const PointList &points,
 }
 
 float MolAligner::compute_measure_for_flip(
-    const PointList &points, const float *flip,
+    const shape::PointList &points, const float *flip,
     measures::MeasuresBase::Ptr measure) {
-  PointList flipped_points;
+  shape::PointList flipped_points;
   get_flipped_points(points, flip, flipped_points);
 
   shape_defs::BitVector curr_fingerprint;
   m_volBox.set_bits_for_spheres(flipped_points, curr_fingerprint, true, 0);
-  return measure->similarity(curr_fingerprint, m_ref_fingerprint);
+  const float result = measure->similarity(curr_fingerprint, m_ref_fingerprint);
+  cerr << "DEBUG: compute_measure_for_flip returns " << result << endl;
+  return result;
 }
 
 void MolAligner::flip_mol(mol::Mol &mol, const float *flip) {

--- a/src/cli/align_monte/mol_aligner.cpp
+++ b/src/cli/align_monte/mol_aligner.cpp
@@ -89,8 +89,6 @@ void MolAligner::process_one_molecule(mol::Mol &mol) {
 void MolAligner::compute_best_sphere_fingerprint(
     const shape::PointList &points, measures::MeasuresBase::Ptr measure,
     unsigned int &i_best, float &best_measure) {
-      ostringstream outs;
-      outs << "DEBUG: compute_best_sphere_fingerprint" << endl;
   i_best = 0;
   best_measure = 0;
   for (unsigned int iFlip = 0; iFlip != c_flip_matrix_size; iFlip++) {
@@ -100,11 +98,7 @@ void MolAligner::compute_best_sphere_fingerprint(
       i_best = iFlip;
       best_measure = currMeasure;
     }
-      outs << "    Flip " << iFlip << " has value " << currMeasure << endl;
   }
-  outs << "  RESULT: flip " << i_best << " with value " << best_measure << endl;
-  cerr << outs.str();
-
 }
 
 static inline void get_flipped_points(const shape::PointList &points,
@@ -132,7 +126,6 @@ float MolAligner::compute_measure_for_flip(
   shape_defs::BitVector curr_fingerprint;
   m_volBox.set_bits_for_spheres(flipped_points, curr_fingerprint, true, 0);
   const float result = measure->similarity(curr_fingerprint, m_ref_fingerprint);
-  cerr << "DEBUG: compute_measure_for_flip returns " << result << endl;
   return result;
 }
 

--- a/src/cli/align_monte/mol_aligner.hpp
+++ b/src/cli/align_monte/mol_aligner.hpp
@@ -9,14 +9,14 @@
 
 #include "mesaac_measures/measures_base.hpp"
 #include "mesaac_mol/mol.hpp"
-#include "mesaac_shape/axis_aligner.hpp"
+#include "mesaac_shape/axis_aligner_eigen.hpp"
 #include "mesaac_shape/vol_box.hpp"
 #include "shared_types.hpp"
 
 namespace mesaac::align_monte {
 class MolAligner {
 public:
-  MolAligner(PointList &hamms_sphere_coords, float epsilon_sqr,
+  MolAligner(shape::PointList &hamms_sphere_coords, float epsilon_sqr,
              shape_defs::BitVector &ref_fp, bool atom_centers_only,
              MeasuresList &measures)
       : m_ref_fingerprint(ref_fp),
@@ -28,15 +28,15 @@ public:
 
 protected:
   const shape_defs::BitVector &m_ref_fingerprint;
-  shape::AxisAligner m_axisAligner;
+  shape::AxisAlignerEigen m_axisAligner;
   shape::VolBox m_volBox;
   MeasuresList &m_measures;
 
-  void compute_best_sphere_fingerprint(const PointList &points,
+  void compute_best_sphere_fingerprint(const shape::PointList &points,
                                        measures::MeasuresBase::Ptr measure,
                                        unsigned int &i_best,
                                        float &best_measure);
-  float compute_measure_for_flip(const PointList &points, const float *flip,
+  float compute_measure_for_flip(const shape::PointList &points, const float *flip,
                                  measures::MeasuresBase::Ptr measure);
   void flip_mol(mol::Mol &mol, const float *flip);
 

--- a/src/cli/align_monte/sdf_mol_aligner.cpp
+++ b/src/cli/align_monte/sdf_mol_aligner.cpp
@@ -43,8 +43,14 @@ struct SortRecord {
   size_t record_num;
   float value;
 
-  static bool compare(const SortRecord &r1, const SortRecord &r2) {
-    return r1.value > r2.value || r1.record_num > r2.record_num;
+  static bool greater(const SortRecord &r1, const SortRecord &r2) {
+    if (r1.value > r2.value) {
+      return true;
+    }
+    if (r1.value < r2.value) {
+      return false;
+    }
+    return r1.record_num > r2.record_num;
   }
 };
 
@@ -63,11 +69,10 @@ float get_tag_value(const mol::Mol &mol, string tag_name) {
   return result;
 }
 
-[[maybe_unused]] void process_mols_conc(mol::SDReader &reader,
-                                        mol::SDWriter &writer, MolAligner &ma,
-                                        bool write_sorted,
-                                        const string &measure_tag,
-                                        SortRecordList &sort_records) {
+void process_mols_conc(mol::SDReader &reader, mol::SDWriter &writer,
+                       MolAligner &ma, bool write_sorted,
+                       const string &measure_tag,
+                       SortRecordList &sort_records) {
 
   using MolPtr = shared_ptr<mol::Mol>;
   using AlignFuture = future<MolPtr>;
@@ -94,28 +99,29 @@ float get_tag_value(const mol::Mol &mol, string tag_name) {
   // i is the sort record index - indicating the order in which
   // each mol was read.  The ref molecule has index 0.
   const size_t i_max = tasks.size();
+  sort_records.reserve(i_max + 1);
+
   for (size_t i = 1; i <= i_max; ++i) {
     auto mol = tasks.front().get();
     tasks.pop_front();
 
     writer.write(*mol);
     if (write_sorted) {
-      sort_records.push_back(SortRecord{i, get_tag_value(*mol, measure_tag)});
+      SortRecord record{i, get_tag_value(*mol, measure_tag)};
+      sort_records.push_back(record);
     }
   }
 }
 
-void write_sorted_records(const filesystem::path& out_pathname, SortRecordList& records, const string& measure_name) {
-      sort(records.begin(), records.end(), SortRecord::compare);
-      ofstream outf(out_pathname);
-
-      outf << "Index\t" << measure_name << endl;
-      SortRecordList::iterator i;
-      for (i = records.begin(); i != records.end(); ++i) {
-        SortRecord &r(*i);
-        outf << r.record_num << "\t" << r.value << endl;
-      }
-      outf.close();
+void write_records(const filesystem::path &out_pathname,
+                   SortRecordList &records, const string &measure_name) {
+  ofstream outf(out_pathname);
+  outf << "Index\t" << measure_name << endl;
+  for (const auto &record : records) {
+    outf << record.record_num << "\t" << record.value << "\n";
+  }
+  outf.flush();
+  outf.close();
 }
 
 } // namespace
@@ -166,7 +172,8 @@ void SDFMolAligner::process_molecules() {
                       sort_records);
 
     if (write_sorted) {
-      write_sorted_records(m_sorted_pathname, sort_records, last_measure);
+      sort(sort_records.begin(), sort_records.end(), SortRecord::greater);
+      write_records(m_sorted_pathname, sort_records, last_measure);
     }
   }
 }

--- a/src/cli/align_monte/sdf_mol_aligner.cpp
+++ b/src/cli/align_monte/sdf_mol_aligner.cpp
@@ -5,13 +5,12 @@
 #include "sdf_mol_aligner.hpp"
 
 #include <algorithm>
+#include <deque>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iostream>
-
-#if HAVE_OPENMP
-#include <omp.h>
-#endif
+#include <vector>
 
 #include "mesaac_mol/io/sdreader.hpp"
 #include "mesaac_mol/io/sdwriter.hpp"
@@ -41,11 +40,11 @@ void open_input(ifstream &inf, string &pathname, const string &description) {
 }
 
 struct SortRecord {
-  int record_num;
+  size_t record_num;
   float value;
 
   static bool compare(const SortRecord &r1, const SortRecord &r2) {
-    return r1.value > r2.value;
+    return r1.value > r2.value || r1.record_num > r2.record_num;
   }
 };
 
@@ -64,6 +63,61 @@ float get_tag_value(const mol::Mol &mol, string tag_name) {
   return result;
 }
 
+[[maybe_unused]] void process_mols_conc(mol::SDReader &reader,
+                                        mol::SDWriter &writer, MolAligner &ma,
+                                        bool write_sorted,
+                                        const string &measure_tag,
+                                        SortRecordList &sort_records) {
+
+  using MolPtr = shared_ptr<mol::Mol>;
+  using AlignFuture = future<MolPtr>;
+  deque<AlignFuture> tasks;
+
+  // Launch an aligner for every mol read.
+  while (!reader.eof()) {
+    const auto read_result = reader.read();
+    if (!read_result.is_ok()) {
+      break;
+    }
+
+    const auto mol = make_shared<mol::Mol>(read_result.value());
+    auto align_task = async(launch::async, [&ma, mol]() {
+      ma.process_one_molecule(*mol);
+      return mol;
+    });
+    tasks.push_back(std::move(align_task));
+  }
+
+  // Immediately start writing mols as they are processed,
+  // in the same order as they are read.
+
+  // i is the sort record index - indicating the order in which
+  // each mol was read.  The ref molecule has index 0.
+  const size_t i_max = tasks.size();
+  for (size_t i = 1; i <= i_max; ++i) {
+    auto mol = tasks.front().get();
+    tasks.pop_front();
+
+    writer.write(*mol);
+    if (write_sorted) {
+      sort_records.push_back(SortRecord{i, get_tag_value(*mol, measure_tag)});
+    }
+  }
+}
+
+void write_sorted_records(const filesystem::path& out_pathname, SortRecordList& records, const string& measure_name) {
+      sort(records.begin(), records.end(), SortRecord::compare);
+      ofstream outf(out_pathname);
+
+      outf << "Index\t" << measure_name << endl;
+      SortRecordList::iterator i;
+      for (i = records.begin(); i != records.end(); ++i) {
+        SortRecord &r(*i);
+        outf << r.record_num << "\t" << r.value << endl;
+      }
+      outf.close();
+}
+
 } // namespace
 
 void SDFMolAligner::run() {
@@ -75,12 +129,9 @@ void SDFMolAligner::read_sphere_points() {
   ifstream inf;
   open_input(inf, m_hamms_sphere_pathname, "Hamms Sphere Points file");
 
-  float coord;
-  while (inf >> coord) {
-    FloatVector point(3, 0.0);
-    point[0] = coord;
-    inf >> point[1] >> point[2];
-    m_hamms_sphere_coords.push_back(point);
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    m_hamms_sphere_coords.emplace_back(shape::Point{x, y, z});
   }
   inf.close();
 }
@@ -101,103 +152,22 @@ void SDFMolAligner::process_molecules() {
   string measure_tag = ">  <MaxAlign" + last_measure + ">";
 
   mol::Mol refmol;
-  int i = 0;
   const auto read_result = reader.read();
   if (read_result.is_ok()) {
     refmol = read_result.value();
     ma.process_ref_molecule(refmol, m_ref_fingerprint);
     writer.write(refmol);
     if (write_sorted) {
-      SortRecord r = {i, get_tag_value(refmol, measure_tag)};
+      SortRecord r{0, get_tag_value(refmol, measure_tag)};
       sort_records.push_back(r);
     }
 
-    i++;
+    process_mols_conc(reader, writer, ma, write_sorted, measure_tag,
+                      sort_records);
 
-#if HAVE_OPENMP
-    const int num_procs = omp_get_num_procs();
-    const int queue_size = 4 * num_procs;
-
-    mol::Mol mol_batch[queue_size];
-    SortRecord sort_record_batch[queue_size];
-    shared_ptr<ostringstream> outstr[queue_size];
-    mol::SDWriter::Ptr buff_writer[queue_size];
-
-    {
-      int j;
-      for (j = 0; j < queue_size; j++) {
-        outstr[j] = make_shared<ostringstream>();
-        outstr[j]->imbue(locale("C"));
-        buff_writer[j] = make_shared<mol::SDWriter>(*outstr[j]);
-      }
+    if (write_sorted) {
+      write_sorted_records(m_sorted_pathname, sort_records, last_measure);
     }
-#endif
-
-    while (true) {
-#if HAVE_OPENMP
-      int j;
-      for (j = 0; j < queue_size; j++) {
-        const auto read_result = reader.read();
-        if (!read_result.is_ok()) {
-          break;
-        }
-        mol_batch[j] = read_result.value();
-      }
-      int num_mols = j;
-#pragma omp parallel for
-      for (j = 0; j < num_mols; j++) {
-        // Is it safe to share access to the ref mol?
-        ma.process_one_molecule(mol_batch[j]);
-        outstr[j]->str("");
-        buff_writer[j]->write(mol_batch[j]);
-        if (write_sorted) {
-          sort_record_batch[j].record_num = i + j;
-          sort_record_batch[j].value = get_tag_value(mol_batch[j], measure_tag);
-        }
-      }
-
-      // Serialize output and accumulation of sort records.
-      for (j = 0; j < num_mols; j++) {
-        cout << outstr[j]->str();
-      }
-      if (write_sorted) {
-        for (j = 0; j < num_mols; j++) {
-          sort_records.push_back(sort_record_batch[j]);
-        }
-      }
-      i += num_mols;
-      if (num_mols < queue_size) {
-        break;
-      }
-#else
-      const auto read_result = reader.read();
-      if (!read_result.is_ok()) {
-        std::cerr << read_result.error() << std::endl;
-        break;
-      }
-      auto mol = read_result.value();
-      ma.process_one_molecule(mol);
-      writer.write(mol);
-      if (write_sorted) {
-        SortRecord r = {i, get_tag_value(mol, measure_tag)};
-        sort_records.push_back(r);
-      }
-      i++;
-#endif
-    }
-  }
-
-  if (write_sorted) {
-    sort(sort_records.begin(), sort_records.end(), SortRecord::compare);
-    ofstream outf(m_sorted_pathname);
-
-    outf << "Index\t" << last_measure << endl;
-    SortRecordList::iterator i;
-    for (i = sort_records.begin(); i != sort_records.end(); ++i) {
-      SortRecord &r(*i);
-      outf << r.record_num << "\t" << r.value << endl;
-    }
-    outf.close();
   }
 }
 } // namespace mesaac::align_monte

--- a/src/cli/align_monte/sdf_mol_aligner.hpp
+++ b/src/cli/align_monte/sdf_mol_aligner.hpp
@@ -5,10 +5,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
-
-// Singular value decomposition, for PCA -- this defines ap::real_2d_array
-#include "svd.h"
 
 #include "shared_types.hpp"
 
@@ -36,7 +32,7 @@ protected:
   MeasuresList &m_measures;
   std::string m_sorted_pathname;
 
-  PointList m_hamms_sphere_coords;
+  shape::PointList m_hamms_sphere_coords;
   shape_defs::BitVector m_ref_fingerprint;
 
   void read_sphere_points();

--- a/src/cli/align_monte/shared_types.hpp
+++ b/src/cli/align_monte/shared_types.hpp
@@ -9,9 +9,5 @@
 #include "mesaac_shape/shared_types.hpp"
 
 namespace mesaac::align_monte {
-typedef shape::Point FloatVector;
-typedef shape::PointList PointList;
-typedef std::vector<PointList> ConformerPointsList;
-
 typedef std::vector<measures::MeasuresBase::Ptr> MeasuresList;
 } // namespace mesaac::align_monte

--- a/src/lib/mesaac_shape/CMakeLists.txt
+++ b/src/lib/mesaac_shape/CMakeLists.txt
@@ -16,9 +16,7 @@ add_library(${TARGET} STATIC ${SRC})
 target_compile_features(${TARGET} PUBLIC cxx_std_20)
 target_include_directories(${TARGET} PUBLIC ${HEADER_DIR})
 target_link_libraries(${TARGET} PUBLIC mesaac_measures mesaac_mol svd ap
-                                       Boost::dynamic_bitset)
-
-target_link_libraries(${TARGET} PUBLIC Eigen3::Eigen)
+                                       Boost::dynamic_bitset Eigen3::Eigen)
 
 target_sources(${TARGET} PUBLIC FILE_SET HEADERS BASE_DIRS ${HEADER_DIR} FILES
                                 ${HEADERS})

--- a/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner_eigen.hpp
+++ b/src/lib/mesaac_shape/include/mesaac_shape/axis_aligner_eigen.hpp
@@ -14,7 +14,7 @@
  * @brief Namespace for shape computations using Eigen.
  */
 namespace mesaac::shape {
-typedef Eigen::Matrix3f Transform;
+using Transform = Eigen::Matrix3f;
 
 class AxisAlignerEigen {
 public:
@@ -44,5 +44,6 @@ protected:
   void transform_points(PointList &all_centers, Transform &transform);
   void update_atom_coords(mesaac::mol::AtomVector &atoms,
                           const PointList &all_centers);
+  void unmirror_axes(Transform &transform);
 };
 } // namespace mesaac::shape

--- a/src/lib/mesaac_shape/src/axis_aligner.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner.cpp
@@ -136,7 +136,7 @@ void AxisAligner::mean_center_points(PointList &points) {
 
 void AxisAligner::get_mean_center(const PointList &points, Point &mean) {
   mean = {0, 0, 0};
-  if (points.size() > 0) {
+  if (!points.empty()) {
     float xsum = 0, ysum = 0, zsum = 0;
     for (const auto &point : points) {
       xsum += point[0];
@@ -161,7 +161,7 @@ void AxisAligner::get_mean_centered_cloud(const PointList &centers,
   cloud.clear();
   if (m_atom_centers_only) {
     for (const auto &center : centers) {
-      cloud.push_back({center[0], center[1], center[2]});
+      cloud.push_back(Point{center[0], center[1], center[2]});
     }
     // Atom centers should already be mean-centered
   } else {

--- a/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
@@ -131,7 +131,7 @@ void AxisAlignerEigen::transform_points(PointList &points, Transform &vt) {
 }
 
 // Note: this *should* be a function in an anonymous namespace.
-// It's a member function so as to be amenable to unit testing.
+// It's a member function so as to ease unit testing.
 void AxisAlignerEigen::unmirror_axes(Transform &transform) {
   const Transform t_orig = transform;
 
@@ -140,7 +140,7 @@ void AxisAlignerEigen::unmirror_axes(Transform &transform) {
     // Is any axis of transform flipped/mirrored?  If not (and if transform
     // doesn't scale any axis to zero) all is good.
     if (transform.determinant() > 0) {
-      break;
+      return;
     }
 
     Transform axis_flip = Transform::Identity();

--- a/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
@@ -8,51 +8,12 @@
 #include <Eigen/Geometry>
 #include <Eigen/SVD>
 
-#include <stdexcept>
 #include <format>
-
+#include <stdexcept>
 
 using namespace std;
 
 namespace mesaac::shape {
-namespace {
-inline bool in_atom(const Point &point, const Point &atom, float eps_sqr) {
-  const float radius(atom.at(3));
-  const float max_bsqr(radius * radius * eps_sqr);
-  double dx(point[0] - atom[0]);
-  const double dx_sqr = dx * dx;
-  // Only bother to calc distance if inside boundary
-  if (dx_sqr <= max_bsqr) {
-    double dy(point[1] - atom[1]);
-    double dz(point[2] - atom[2]);
-    float dsqr = dx_sqr + (dy * dy) + (dz * dz);
-    return (dsqr <= max_bsqr);
-  }
-  return false;
-}
-
-void unmirror_axes(Transform &vt) {
-  
-  const Transform vt_orig = vt;
-
-  for (unsigned int i = 0; i != 3; i++) {
-    // Is any axis of vt flipped/mirrored?  If not (and if vt doesn't
-    // scale any axis to zero) we're good.
-    if (vt.determinant() > 0) {
-      break;
-    }
-
-    Transform axis_flip = Transform::Identity();
-    axis_flip(i, i) = -1;
-    vt = axis_flip * vt_orig;
-  }
-
-  if (vt.determinant() < 0) {
-    throw std::runtime_error("AxisAlignerEigen could not unmirror axes.");
-  }
-}
-
-} // namespace
 
 void AxisAlignerEigen::align_to_axes(mol::Mol &m) {
   align_to_axes(m.mutable_atoms());
@@ -166,6 +127,29 @@ void AxisAlignerEigen::transform_points(PointList &points, Transform &vt) {
     p[0] = transformed[0];
     p[1] = transformed[1];
     p[2] = transformed[2];
+  }
+}
+
+// Note: this *should* be a function in an anonymous namespace.
+// It's a member function so as to be amenable to unit testing.
+void AxisAlignerEigen::unmirror_axes(Transform &transform) {
+  const Transform t_orig = transform;
+
+  // Try flipping one axis at a time, until the result has no mirrored axes.
+  for (unsigned int i = 0; i != 3; i++) {
+    // Is any axis of transform flipped/mirrored?  If not (and if transform
+    // doesn't scale any axis to zero) all is good.
+    if (transform.determinant() > 0) {
+      break;
+    }
+
+    Transform axis_flip = Transform::Identity();
+    axis_flip(i, i) = -1;
+    transform = axis_flip * t_orig;
+  }
+
+  if (transform.determinant() < 0) {
+    throw std::runtime_error("Could not unmirror axes.");
   }
 }
 

--- a/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
+++ b/src/lib/mesaac_shape/src/axis_aligner_eigen.cpp
@@ -7,8 +7,10 @@
 
 #include <Eigen/Geometry>
 #include <Eigen/SVD>
-#include <sstream>
+
 #include <stdexcept>
+#include <format>
+
 
 using namespace std;
 
@@ -29,38 +31,24 @@ inline bool in_atom(const Point &point, const Point &atom, float eps_sqr) {
   return false;
 }
 
-bool axis_is_mirrored(Transform &vt) {
-  // Transform 3 unit "vectors" such that the 3rd is the cross product
-  // of the first 2.  After transformation, confirm it is still the
-  // cross product.
-
-  // TODO:  Figure out how to use Vector4f and a 4x4 transform
-  // matrix.  Eigen may be able to perform better this way because
-  // of auto-vectorization packet sizes.
-  typedef Eigen::Vector3f EPoint;
-  EPoint a, b, c;
-  // Why is this epsilon faster than EPoint(1.0, 0.0, 0.0) etc.?
-  a << 1.0, 0.0, 0.0;
-  b << 0.0, 1.0, 0.0;
-  c << 0.0, 0.0, 1.0;
-  a = vt * a;
-  b = vt * b;
-  c = vt * c;
-  EPoint xp(a.cross(b));
-  return !(c - xp).isZero();
-}
-
 void unmirror_axes(Transform &vt) {
+  
+  const Transform vt_orig = vt;
+
   for (unsigned int i = 0; i != 3; i++) {
-    if (!axis_is_mirrored(vt)) {
+    // Is any axis of vt flipped/mirrored?  If not (and if vt doesn't
+    // scale any axis to zero) we're good.
+    if (vt.determinant() > 0) {
       break;
     }
-    vt(i) *= -1;
-    if (axis_is_mirrored(vt)) {
-      // Still mirrored?  Back off and try again w. the next
-      // axis.
-      vt(i) *= -1;
-    }
+
+    Transform axis_flip = Transform::Identity();
+    axis_flip(i, i) = -1;
+    vt = axis_flip * vt_orig;
+  }
+
+  if (vt.determinant() < 0) {
+    throw std::runtime_error("AxisAlignerEigen could not unmirror axes.");
   }
 }
 
@@ -116,30 +104,25 @@ void AxisAlignerEigen::mean_center_points(PointList &points) {
 }
 
 void AxisAlignerEigen::get_mean_center(const PointList &points, Point &mean) {
-  mean.clear();
-  if (points.size() == 0) {
-    mean.push_back(0);
-    mean.push_back(0);
-    mean.push_back(0);
-  } else {
+  mean = {0, 0, 0};
+  if (!points.empty()) {
     float xsum = 0, ysum = 0, zsum = 0;
-    for (const auto &p : points) {
-      xsum += p[0];
-      ysum += p[1];
-      zsum += p[2];
+    for (const auto &point : points) {
+      xsum += point[0];
+      ysum += point[1];
+      zsum += point[2];
     }
-    mean.push_back(xsum / points.size());
-    mean.push_back(ysum / points.size());
-    mean.push_back(zsum / points.size());
+    const auto npts = points.size();
+    mean = {xsum / npts, ysum / npts, zsum / npts};
   }
 }
 
 void AxisAlignerEigen::untranslate_points(PointList &points,
                                           const Point &offset) {
-  for (auto &p : points) {
-    p[0] -= offset[0];
-    p[1] -= offset[1];
-    p[2] -= offset[2];
+  for (auto &point : points) {
+    point[0] -= offset[0];
+    point[1] -= offset[1];
+    point[2] -= offset[2];
   }
 }
 
@@ -160,10 +143,9 @@ void AxisAlignerEigen::get_mean_centered_cloud(const PointList &centers,
 void AxisAlignerEigen::update_atom_coords(mol::AtomVector &atoms,
                                           const PointList &atom_centers) {
   if (atoms.size() != atom_centers.size()) {
-    ostringstream msg;
-    msg << "Atom vector length " << atoms.size()
-        << " must equal atom centers length " << atom_centers.size();
-    throw length_error(msg.str());
+    throw std::length_error(
+        std::format("Atom vector length {} must equal atom centers length {}",
+                    atoms.size(), atom_centers.size()));
   }
 
   mol::AtomVector::iterator atom_iter(atoms.begin());
@@ -189,7 +171,7 @@ void AxisAlignerEigen::transform_points(PointList &points, Transform &vt) {
 
 void AxisAlignerEigen::find_axis_align_transform(const PointList &cloud,
                                                  Transform &transform) {
-  if (cloud.size() <= 0) {
+  if (cloud.empty()) {
     // TODO: Instead of failing, just return the identity transform.
     throw invalid_argument("Can't find alignment for empty cloud");
   }

--- a/tests/src/cli/align_monte/CMakeLists.txt
+++ b/tests/src/cli/align_monte/CMakeLists.txt
@@ -15,3 +15,12 @@ foreach(SCRIPT_NAME ${TEST_SCRIPTS})
     PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>"
                LABELS "mesaac;align_monte")
 endforeach()
+
+# Check performance.
+add_test(NAME benchmark_align_monte
+         COMMAND Python3::Interpreter
+                 ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_align_monte.py)
+set_tests_properties(
+  benchmark_align_monte
+  PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>"
+             LABELS "mesaac;mesaac_benchmark;align_monte")

--- a/tests/src/cli/align_monte/benchmark_align_monte.py
+++ b/tests/src/cli/align_monte/benchmark_align_monte.py
@@ -1,0 +1,34 @@
+import subprocess
+import time
+
+import config
+
+exe = config.EXE
+sd_path = config.TEST_DATA_DIR / "cox2_3d.sd"
+spheroid_path = (
+    config.SHARED_TEST_DATA_DIR / "hammersley" / "hamm_spheroid_20k_11rad.txt"
+)
+
+
+def run_benchmark_once() -> None:
+    subprocess.check_call(
+        [exe, sd_path, spheroid_path, "1.0"],
+        stdout=subprocess.DEVNULL,
+        # stderr=subprocess.DEVNULL,
+    )
+
+
+def run_benchmark(num_runs: int) -> float:
+    t0 = time.time()
+    for i in range(num_runs):
+        run_benchmark_once()
+    return (time.time() - t0) / num_runs
+
+
+def main() -> None:
+    mean = run_benchmark(20)
+    print(f"Mean runtime: {mean:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/src/cli/align_monte/test_basics.py
+++ b/tests/src/cli/align_monte/test_basics.py
@@ -177,7 +177,7 @@ class TestCase(btc.TestCaseBase):
             / "hammersley"
             / "hamm_spheroid_20k_11rad.txt"
         )
-        options = options or []
+        options = [str(v) for v in (options or [])]
         args = options + [str(sd_pathname), str(hamm_sphere), "1.0"]
         return self._run(*args)
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner.cpp
@@ -63,261 +63,256 @@ public:
   }
 };
 
-class TestFixture {
-public:
-  void get_point_means(const PointList &points, float &x, float &y, float &z) {
-    x = y = z = 0.0;
-    if (points.size()) {
-      float xsum = 0, ysum = 0, zsum = 0;
-      for (const auto p : points) {
-        xsum += p[0];
-        ysum += p[1];
-        zsum += p[2];
+void get_point_means(const PointList &points, float &x, float &y, float &z) {
+  x = y = z = 0.0;
+  if (points.size()) {
+    float xsum = 0, ysum = 0, zsum = 0;
+    for (const auto p : points) {
+      xsum += p[0];
+      ysum += p[1];
+      zsum += p[2];
+    }
+    x = xsum / points.size();
+    y = ysum / points.size();
+    z = zsum / points.size();
+  }
+}
+
+// Find the extent of set of points, along each axis.
+void get_point_extents(const PointList &points, float &dx, float &dy,
+                       float &dz) {
+  dx = dy = dz = 0.0;
+  if (points.size()) {
+    bool first = true;
+    float xmin = 0, ymin = 0, zmin = 0, xmax = 0, ymax = 0, zmax = 0;
+    for (const Point &p : points) {
+      if (first) {
+        xmin = xmax = p[0];
+        ymin = ymax = p[1];
+        zmin = zmax = p[2];
+        first = false;
+      } else {
+        xmin = min(xmin, p[0]);
+        xmax = max(xmax, p[0]);
+        ymin = min(ymin, p[1]);
+        ymax = max(ymax, p[1]);
+        zmin = min(zmin, p[2]);
+        zmax = max(zmax, p[2]);
       }
-      x = xsum / points.size();
-      y = ysum / points.size();
-      z = zsum / points.size();
     }
+    dx = xmax - xmin;
+    dy = ymax - ymin;
+    dz = zmax - zmin;
   }
+}
 
-  // Find the extent of set of points, along each axis.
-  void get_point_extents(const PointList &points, float &dx, float &dy,
-                         float &dz) {
-    dx = dy = dz = 0.0;
-    if (points.size()) {
-      bool first = true;
-      float xmin = 0, ymin = 0, zmin = 0, xmax = 0, ymax = 0, zmax = 0;
-      for (const Point &p : points) {
-        if (first) {
-          xmin = xmax = p[0];
-          ymin = ymax = p[1];
-          zmin = zmax = p[2];
-          first = false;
-        } else {
-          xmin = min(xmin, p[0]);
-          xmax = max(xmax, p[0]);
-          ymin = min(ymin, p[1]);
-          ymax = max(ymax, p[1]);
-          zmin = min(zmin, p[2]);
-          zmax = max(zmax, p[2]);
-        }
+void read_test_points(const filesystem::path &pathname, PointList &points) {
+  // Use the test data directory specified by TEST_DATA_DIR preprocessor
+  // symbol.
+  const filesystem::path test_data_dir(TEST_DATA_DIR);
+  const auto data_dir(test_data_dir / "hammersley/");
+  const auto full_path(data_dir / pathname);
+  points.clear();
+  ifstream inf(full_path);
+  if (!inf) {
+    ostringstream msg;
+    msg << "Could not open " << pathname << " for reading." << endl;
+    throw std::runtime_error(msg.str());
+  }
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    points.push_back({x, y, z});
+  }
+  inf.close();
+}
+
+std::unique_ptr<TCAxisAligner> new_aligner() {
+  PointList sphere;
+  float atom_scale = 1.0;
+
+  // Assume we will be run in a location fixed relative to
+  // the data files.
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAligner>(sphere, atom_scale, false);
+}
+
+std::unique_ptr<TCAxisAligner> new_aligner_ac_only() {
+  PointList sphere;
+  float atom_scale = 1.0;
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAligner>(sphere, atom_scale, true);
+}
+
+mol::Atom atom(string symbol, float x, float y, float z) {
+  const unsigned char atomic_num(mol::get_atomic_num(symbol));
+  return mol::Atom({atomic_num, {x, y, z}});
+}
+
+void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) {
+  // Coordinates taken from first cox2_3d conformer.
+  mol::AtomVector atoms{
+      atom("C", 27.7051, 22.0403, 17.0243),
+      atom("N", 26.4399, 22.0976, 16.4318),
+      atom("C", 25.5381, 21.4424, 17.2831),
+      atom("C", 26.2525, 20.9753, 18.3748),
+      atom("C", 27.5943, 21.3608, 18.2218),
+      atom("C", 24.0821, 21.3670, 17.1082),
+      atom("C", 26.1324, 22.6824, 15.1634),
+      atom("C", 23.4105, 22.2668, 16.2675),
+      atom("C", 22.0220, 22.2007, 16.1197),
+      atom("C", 21.2976, 21.2409, 16.8307),
+      atom("C", 21.9509, 20.3402, 17.6750),
+      atom("C", 23.3399, 20.4115, 17.8175),
+      atom("C", 26.3695, 24.0457, 14.9358),
+      atom("C", 26.0627, 24.6119, 13.6959),
+      atom("C", 25.5236, 23.8179, 12.6910),
+      atom("C", 25.2821, 22.4660, 12.9010),
+      atom("C", 25.5848, 21.8942, 14.1391),
+      atom("F", 25.2311, 24.3643, 11.5034),
+      atom("C", 28.9655, 22.5443, 16.4025),
+      atom("S", 19.5328, 21.1457, 16.6315),
+      atom("O", 19.0413, 22.4851, 16.3229),
+      atom("O", 18.9873, 20.4577, 17.7975),
+      atom("C", 19.3258, 20.1152, 15.2035),
+      atom("H", 25.8309, 20.4354, 19.2156),
+      atom("H", 28.4100, 21.1477, 18.9041),
+      atom("H", 23.9630, 23.0298, 15.7210),
+      atom("H", 21.5209, 22.9035, 15.4575),
+      atom("H", 21.3956, 19.5863, 18.2287),
+      atom("H", 23.8404, 19.7079, 18.4815),
+      atom("H", 26.7480, 24.6961, 15.7203),
+      atom("H", 26.2341, 25.6696, 13.5167),
+      atom("H", 24.8658, 21.8592, 12.1019),
+      atom("H", 25.4187, 20.8273, 14.2701),
+      atom("H", 29.8338, 22.0387, 16.8401),
+      atom("H", 29.0870, 23.6157, 16.5858),
+      atom("H", 28.9947, 22.3510, 15.3261),
+      atom("H", 18.2555, 20.0118, 15.0126),
+      atom("H", 19.7633, 19.1356, 15.4046),
+      atom("H", 19.8115, 20.5898, 14.3489),
+  };
+  mol = mol::Mol({.atoms = atoms});
+  num_heavies = 23;
+}
+
+void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
+  mol::Mol m;
+
+  create_sample_mol(m, num_heavies);
+  // Take care to deep-copy all of the atom pointers.
+  atoms.clear();
+  const mol::AtomVector &src(m.atoms());
+  for (const auto src_atom : src) {
+    atoms.push_back(src_atom);
+  }
+}
+
+bool coords_match(const mol::AtomVector &atoms, const PointList &points,
+                  unsigned int count) {
+  // cout << "coords_match? " << endl
+  //      << "  # atoms:    " << atoms.size() << endl
+  //      << "  # points:   " << points.size() << endl
+  //      << "  # to check: " << count << endl;
+  if ((atoms.size() >= count) && (points.size() >= count)) {
+    for (int i = count - 1; i >= 0; --i) {
+      const mol::Atom &a(atoms[i]);
+      const Point &p(points[i]);
+      const mol::Position &pos(a.pos());
+      if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
+        return false;
       }
-      dx = xmax - xmin;
-      dy = ymax - ymin;
-      dz = zmax - zmin;
     }
+    return true;
   }
+  return false;
+}
 
-  void read_test_points(const filesystem::path &pathname, PointList &points) {
-    // Use the test data directory specified by TEST_DATA_DIR preprocessor
-    // symbol.
-    const filesystem::path test_data_dir(TEST_DATA_DIR);
-    const auto data_dir(test_data_dir / "hammersley/");
-    const auto full_path(data_dir / pathname);
-    points.clear();
-    ifstream inf(full_path);
-    if (!inf) {
-      ostringstream msg;
-      msg << "Could not open " << pathname << " for reading." << endl;
-      throw std::runtime_error(msg.str());
-    }
-    float x, y, z;
-    while (inf >> x >> y >> z) {
-      points.push_back({x, y, z});
-    }
-    inf.close();
-  }
-
-  std::unique_ptr<TCAxisAligner> new_aligner() {
-    PointList sphere;
-    float atom_scale = 1.0;
-
-    // Assume we will be run in a location fixed relative to
-    // the data files.
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAligner>(sphere, atom_scale, false);
-  }
-
-  std::unique_ptr<TCAxisAligner> new_aligner_ac_only() {
-    PointList sphere;
-    float atom_scale = 1.0;
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAligner>(sphere, atom_scale, true);
-  }
-
-  mol::Atom atom(string symbol, float x, float y, float z) const {
-    const unsigned char atomic_num(mol::get_atomic_num(symbol));
-    return mol::Atom({atomic_num, {x, y, z}});
-  }
-
-  void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) const {
-    // Coordinates taken from first cox2_3d conformer.
-    mol::AtomVector atoms{
-        atom("C", 27.7051, 22.0403, 17.0243),
-        atom("N", 26.4399, 22.0976, 16.4318),
-        atom("C", 25.5381, 21.4424, 17.2831),
-        atom("C", 26.2525, 20.9753, 18.3748),
-        atom("C", 27.5943, 21.3608, 18.2218),
-        atom("C", 24.0821, 21.3670, 17.1082),
-        atom("C", 26.1324, 22.6824, 15.1634),
-        atom("C", 23.4105, 22.2668, 16.2675),
-        atom("C", 22.0220, 22.2007, 16.1197),
-        atom("C", 21.2976, 21.2409, 16.8307),
-        atom("C", 21.9509, 20.3402, 17.6750),
-        atom("C", 23.3399, 20.4115, 17.8175),
-        atom("C", 26.3695, 24.0457, 14.9358),
-        atom("C", 26.0627, 24.6119, 13.6959),
-        atom("C", 25.5236, 23.8179, 12.6910),
-        atom("C", 25.2821, 22.4660, 12.9010),
-        atom("C", 25.5848, 21.8942, 14.1391),
-        atom("F", 25.2311, 24.3643, 11.5034),
-        atom("C", 28.9655, 22.5443, 16.4025),
-        atom("S", 19.5328, 21.1457, 16.6315),
-        atom("O", 19.0413, 22.4851, 16.3229),
-        atom("O", 18.9873, 20.4577, 17.7975),
-        atom("C", 19.3258, 20.1152, 15.2035),
-        atom("H", 25.8309, 20.4354, 19.2156),
-        atom("H", 28.4100, 21.1477, 18.9041),
-        atom("H", 23.9630, 23.0298, 15.7210),
-        atom("H", 21.5209, 22.9035, 15.4575),
-        atom("H", 21.3956, 19.5863, 18.2287),
-        atom("H", 23.8404, 19.7079, 18.4815),
-        atom("H", 26.7480, 24.6961, 15.7203),
-        atom("H", 26.2341, 25.6696, 13.5167),
-        atom("H", 24.8658, 21.8592, 12.1019),
-        atom("H", 25.4187, 20.8273, 14.2701),
-        atom("H", 29.8338, 22.0387, 16.8401),
-        atom("H", 29.0870, 23.6157, 16.5858),
-        atom("H", 28.9947, 22.3510, 15.3261),
-        atom("H", 18.2555, 20.0118, 15.0126),
-        atom("H", 19.7633, 19.1356, 15.4046),
-        atom("H", 19.8115, 20.5898, 14.3489),
-    };
-    mol = mol::Mol({.atoms = atoms});
-    num_heavies = 23;
-  }
-
-  void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
-    mol::Mol m;
-
-    create_sample_mol(m, num_heavies);
-    // Take care to deep-copy all of the atom pointers.
-    atoms.clear();
-    const mol::AtomVector &src(m.atoms());
-    for (const auto src_atom : src) {
-      atoms.push_back(src_atom);
-    }
-  }
-
-  bool coords_match(const mol::AtomVector &atoms, const PointList &points,
-                    unsigned int count) {
-    // cout << "coords_match? " << endl
-    //      << "  # atoms:    " << atoms.size() << endl
-    //      << "  # points:   " << points.size() << endl
-    //      << "  # to check: " << count << endl;
-    if ((atoms.size() >= count) && (points.size() >= count)) {
-      for (int i = count - 1; i >= 0; --i) {
-        const mol::Atom &a(atoms[i]);
-        const Point &p(points[i]);
-        const mol::Position &pos(a.pos());
-        if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
-          return false;
-        }
-      }
-      return true;
-    }
-    return false;
-  }
-
-  void get_pointlist_info(const PointList &points, float &xmid, float &ymid,
-                          float &zmid, float &width, float &height,
-                          float &depth) {
-    xmid = ymid = zmid = width = height = depth = 0.0;
-    if (points.size()) {
-      float xmin, ymin, zmin, xmax, ymax, zmax;
-      float xsum = 0, ysum = 0, zsum = 0;
-      bool first = true;
-      for (const auto &point : points) {
-        const float x(point[0]), y(point[1]), z(point[2]);
-        xsum += x;
-        ysum += y;
-        zsum += z;
-
-        if (first) {
-          xmin = xmax = x;
-          ymin = ymax = y;
-          zmin = zmax = z;
-          first = false;
-        } else {
-          xmin = min(xmin, x);
-          xmax = max(xmax, x);
-          ymin = min(ymin, y);
-          ymax = max(ymax, y);
-          zmin = min(zmin, z);
-          zmax = max(zmax, z);
-        }
-      }
-
-      xmid = xsum / points.size();
-      ymid = ysum / points.size();
-      zmid = zsum / points.size();
-      width = xmax - xmin;
-      height = ymax - ymin;
-      depth = zmax - zmin;
-    }
-  }
-
-  bool is_mean_centered(const PointList &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    std::cerr << "DEBUG: is_mean_centered midpoint: " << xmid << ", " << ymid
-              << ", " << zmid << std::endl;
-    auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
-    return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
-  }
-
-  bool has_nonincreasing_extents(const PointList &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    bool result = ((w >= h) && (h >= d) && (d > 0));
-    return result;
-  }
-
-  float find_max_radius(const PointList &points) {
-    float result = 0.0;
+void get_pointlist_info(const PointList &points, float &xmid, float &ymid,
+                        float &zmid, float &width, float &height,
+                        float &depth) {
+  xmid = ymid = zmid = width = height = depth = 0.0;
+  if (points.size()) {
+    float xmin, ymin, zmin, xmax, ymax, zmax;
+    float xsum = 0, ysum = 0, zsum = 0;
+    bool first = true;
     for (const auto &point : points) {
-      result = max(result, point.at(3));
-    }
-    return result;
-  }
+      const float x(point[0]), y(point[1]), z(point[2]);
+      xsum += x;
+      ysum += y;
+      zsum += z;
 
-  bool is_non_null_transform(Transform &a) {
-    // WEAK!
-    int low_row = a.getlowbound(1);
-    int high_row = a.gethighbound(1);
-    int low_col = a.getlowbound(2);
-    int high_col = a.gethighbound(2);
-    bool result = (((high_row - low_row) == 2) && ((high_col - low_col) == 2));
-    if (result) {
-      result = false;
-      for (int r = low_row; !result && (r <= high_row); r++) {
-        ap::raw_vector<double> row_v = a.getrow(r, low_col, high_col);
-        double *curr_col = row_v.GetData();
-        for (int icol = low_col; !result && (icol <= high_col); ++icol) {
-          result = (*curr_col != 0.0);
-          curr_col++;
-        }
+      if (first) {
+        xmin = xmax = x;
+        ymin = ymax = y;
+        zmin = zmax = z;
+        first = false;
+      } else {
+        xmin = min(xmin, x);
+        xmax = max(xmax, x);
+        ymin = min(ymin, y);
+        ymax = max(ymax, y);
+        zmin = min(zmin, z);
+        zmax = max(zmax, z);
       }
     }
-    return result;
+
+    xmid = xsum / points.size();
+    ymid = ysum / points.size();
+    zmid = zsum / points.size();
+    width = xmax - xmin;
+    height = ymax - ymin;
+    depth = zmax - zmin;
   }
-};
-} // namespace
+}
+
+bool is_mean_centered(const PointList &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  std::cerr << "DEBUG: is_mean_centered midpoint: " << xmid << ", " << ymid
+            << ", " << zmid << std::endl;
+  auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
+  return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
+}
+
+bool has_nonincreasing_extents(const PointList &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  bool result = ((w >= h) && (h >= d) && (d > 0));
+  return result;
+}
+
+float find_max_radius(const PointList &points) {
+  float result = 0.0;
+  for (const auto &point : points) {
+    result = max(result, point.at(3));
+  }
+  return result;
+}
+
+bool is_non_null_transform(Transform &a) {
+  // WEAK!
+  int low_row = a.getlowbound(1);
+  int high_row = a.gethighbound(1);
+  int low_col = a.getlowbound(2);
+  int high_col = a.gethighbound(2);
+  bool result = (((high_row - low_row) == 2) && ((high_col - low_col) == 2));
+  if (result) {
+    result = false;
+    for (int r = low_row; !result && (r <= high_row); r++) {
+      ap::raw_vector<double> row_v = a.getrow(r, low_col, high_col);
+      double *curr_col = row_v.GetData();
+      for (int icol = low_col; !result && (icol <= high_col); ++icol) {
+        result = (*curr_col != 0.0);
+        curr_col++;
+      }
+    }
+  }
+  return result;
+}
 
 TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   // This setup is performed separately for each section.
-  TestFixture fixture;
-  std::unique_ptr<TCAxisAligner> aligner(fixture.new_aligner());
+  std::unique_ptr<TCAxisAligner> aligner(new_aligner());
   mol::AtomVector atoms;
   PointList points;
 
@@ -333,14 +328,14 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   SECTION("Get atom coords from a vector of heavy atoms") {
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     REQUIRE(atoms.size() > num_heavies);
     REQUIRE(num_heavies > 0);
-    REQUIRE(fixture.coords_match(atoms, points, num_heavies));
+    REQUIRE(coords_match(atoms, points, num_heavies));
 
     aligner->tc_get_atom_points(atoms, points, true);
-    REQUIRE(fixture.coords_match(atoms, points, atoms.size()));
+    REQUIRE(coords_match(atoms, points, atoms.size()));
   }
 
   SECTION("Get the mean center of an empty list of points") {
@@ -357,7 +352,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     unsigned int num_heavies;
     Point center;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     aligner->tc_get_mean_center(points, center);
     REQUIRE(center.size() == 3);
@@ -383,15 +378,15 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
     // TODO:  create a set of atoms w. known positions and
     // easily verified extents.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     REQUIRE((size_t)num_heavies == points.size());
     aligner->tc_mean_center_points(points);
     REQUIRE((size_t)num_heavies == points.size());
-    REQUIRE(fixture.is_mean_centered(points));
+    REQUIRE(is_mean_centered(points));
 
     float xmid, ymid, zmid, width, height, depth;
-    fixture.get_pointlist_info(points, xmid, ymid, zmid, width, height, depth);
+    get_pointlist_info(points, xmid, ymid, zmid, width, height, depth);
     REQUIRE_THAT(width, Catch::Matchers::WithinAbs(9.9782, 0.00001));
     REQUIRE_THAT(height, Catch::Matchers::WithinAbs(4.4967, 0.00001));
     REQUIRE_THAT(depth, Catch::Matchers::WithinAbs(6.8714, 0.00001));
@@ -408,7 +403,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   SECTION("Get mean-centered cloud -- non-empty") {
     unsigned int num_heavies;
     PointList cloud;
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     REQUIRE(!points.empty());
     REQUIRE(points.size() == num_heavies);
@@ -419,17 +414,15 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE(!cloud.empty());
 
     float xmid, ymid, zmid, pwidth, pheight, pdepth;
-    fixture.get_pointlist_info(points, xmid, ymid, zmid, pwidth, pheight,
-                               pdepth);
-    REQUIRE(fixture.is_mean_centered(points));
+    get_pointlist_info(points, xmid, ymid, zmid, pwidth, pheight, pdepth);
+    REQUIRE(is_mean_centered(points));
     REQUIRE_THAT(pwidth, Catch::Matchers::WithinAbs(9.9782, 0.00001));
     REQUIRE_THAT(pheight, Catch::Matchers::WithinAbs(4.4967, 0.00001));
     REQUIRE_THAT(pdepth, Catch::Matchers::WithinAbs(6.8714, 0.00001));
 
     float cwidth, cheight, cdepth;
-    fixture.get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight,
-                               cdepth);
-    float dmax = 2.0 * fixture.find_max_radius(points);
+    get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight, cdepth);
+    float dmax = 2.0 * find_max_radius(points);
 
     // Hardwired badness: max radius of all atoms in create_sample_atoms should
     // be that of sulfur.
@@ -451,7 +444,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     PointList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     aligner->tc_mean_center_points(points);
     aligner->tc_get_mean_centered_cloud(points, cloud);
@@ -459,9 +452,9 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     // Not sure how to test this.  Just confirm it's a 3x3 matrix
     // with non-empty cells?
     Transform transform;
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
   }
 
   SECTION("Untranslate points") {
@@ -498,14 +491,14 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE_THROWS_AS(aligner->tc_find_axis_align_transform(cloud, transform),
                       invalid_argument);
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     aligner->tc_mean_center_points(points);
     aligner->tc_get_mean_centered_cloud(points, cloud);
 
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
 
     // Verify no crash on an empty point list.
     points.clear();
@@ -513,13 +506,13 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     REQUIRE(points.empty());
 
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     aligner->tc_transform_points(points, transform);
     REQUIRE(points.size() == num_heavies);
 
     // Transform should merely rotate the points -- no mean-centering.
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Update atom coords") {
@@ -528,7 +521,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
     // Ensure correct copying of transformed point coords to
     // corresponding atom coords.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
 
     // Point and atom lists of different size?  This should fail.
     aligner->tc_get_atom_points(atoms, points, false);
@@ -561,16 +554,16 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     PointList points, cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!is_mean_centered(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(atoms);
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(is_mean_centered(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Align mol to axes") {
@@ -583,20 +576,20 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     PointList points, cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!is_mean_centered(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(is_mean_centered(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Align to axes - mol only") {
-    std::unique_ptr<TCAxisAligner> aligner(fixture.new_aligner_ac_only());
+    std::unique_ptr<TCAxisAligner> aligner(new_aligner_ac_only());
     mol::Mol mol;
 
     // No crash on empty:
@@ -606,18 +599,18 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     PointList points, cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!is_mean_centered(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     // TODO:  Check that the hydrogens are also transformed.
     // TODO:  Check that align_to_axes with atom-centers-only produces
     // different results than without atom-centers-only.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(is_mean_centered(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Align hydrogens") {
@@ -627,20 +620,19 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
 
     float x, y, z, w, h, d;
 
-    mol::Mol mol(
-        {.atoms = {
-             fixture.atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
-             fixture.atom("H", 0.0, 0.0, 1.0),
-             fixture.atom("C", 0.0, 0.0, 2.0),
-             fixture.atom("H", 0.0, 0.0, 3.0),
-             fixture.atom("C", 0.0, 0.0, 4.0),
-             fixture.atom("H", 0.0, 0.0, 5.0),
-             fixture.atom("C", 0.0, 0.0, 6.0),
-             fixture.atom("H", 0.0, 0.0, 7.0),
-         }});
+    mol::Mol mol({.atoms = {
+                      atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
+                      atom("H", 0.0, 0.0, 1.0),
+                      atom("C", 0.0, 0.0, 2.0),
+                      atom("H", 0.0, 0.0, 3.0),
+                      atom("C", 0.0, 0.0, 4.0),
+                      atom("H", 0.0, 0.0, 5.0),
+                      atom("C", 0.0, 0.0, 6.0),
+                      atom("H", 0.0, 0.0, 7.0),
+                  }});
 
     aligner->tc_get_atom_points(mol.atoms(), points, true);
-    fixture.get_pointlist_info(points, x, y, z, w, h, d);
+    get_pointlist_info(points, x, y, z, w, h, d);
 
     REQUIRE_THAT(w, Catch::Matchers::WithinAbs(0.0f, 0.00001));
     REQUIRE_THAT(h, Catch::Matchers::WithinAbs(0.0f, 0.00001));
@@ -649,7 +641,7 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), points, true);
 
-    fixture.get_pointlist_info(points, x, y, z, w, h, d);
+    get_pointlist_info(points, x, y, z, w, h, d);
 
     // The slope from point to point should be consistent.
     const float dx_dy = w / h;
@@ -701,14 +693,12 @@ TEST_CASE("mesaac::shape::AxisAligner", "[mesaac]") {
   }
 }
 
-namespace {
-int benchmark_align_to_axes(const TestFixture &fixture,
-                            std::shared_ptr<TCAxisAligner> aligner) {
+int benchmark_align_to_axes(std::shared_ptr<TCAxisAligner> aligner) {
   mol::Mol mol;
   PointList points, cloud;
   unsigned int num_heavies;
 
-  fixture.create_sample_mol(mol, num_heavies);
+  create_sample_mol(mol, num_heavies);
   aligner->tc_get_atom_points(mol.atoms(), points, false);
 
   // TODO:  Check that the hydrogens are also transformed.
@@ -719,22 +709,16 @@ int benchmark_align_to_axes(const TestFixture &fixture,
 
 TEST_CASE("mesaac::shape::AxisAligner Benchmarks",
           "[mesaac][mesaac_benchmark]") {
-  TestFixture fixture;
-
   BENCHMARK_ADVANCED("Point cloud alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAligner> aligner(fixture.new_aligner());
-    meter.measure([fixture, aligner] {
-      return benchmark_align_to_axes(fixture, aligner);
-    });
+    std::shared_ptr<TCAxisAligner> aligner(new_aligner());
+    meter.measure([aligner] { return benchmark_align_to_axes(aligner); });
   };
 
   BENCHMARK_ADVANCED("Atom center alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAligner> ac_aligner(fixture.new_aligner_ac_only());
-    meter.measure([fixture, ac_aligner] {
-      return benchmark_align_to_axes(fixture, ac_aligner);
-    });
+    std::shared_ptr<TCAxisAligner> ac_aligner(new_aligner_ac_only());
+    meter.measure([ac_aligner] { return benchmark_align_to_axes(ac_aligner); });
   };
 }
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
@@ -64,242 +64,239 @@ public:
   }
 };
 
-struct TestFixture {
-  void get_point_means(const PointList &points, float &x, float &y, float &z) {
-    x = y = z = 0.0;
-    if (points.size()) {
-      float xsum = 0, ysum = 0, zsum = 0;
-      for (const auto &point : points) {
-        xsum += point[0];
-        ysum += point[1];
-        zsum += point[2];
-      }
-      x = xsum / points.size();
-      y = ysum / points.size();
-      z = zsum / points.size();
-    }
-  }
-
-  // Find the extent of set of points, along each axis.
-  void get_point_extents(const PointList &points, float &dx, float &dy,
-                         float &dz) {
-    dx = dy = dz = 0.0;
-    if (points.size()) {
-      float xmin = 0, ymin = 0, zmin = 0, xmax = 0, ymax = 0, zmax = 0;
-      bool first = true;
-      for (const auto &point : points) {
-        if (first) {
-          xmin = xmax = point[0];
-          ymin = ymax = point[1];
-          zmin = zmax = point[2];
-          first = false;
-        } else {
-          xmin = min(xmin, point[0]);
-          xmax = max(xmax, point[0]);
-          ymin = min(ymin, point[1]);
-          ymax = max(ymax, point[1]);
-          zmin = min(zmin, point[2]);
-          zmax = max(zmax, point[2]);
-        }
-      }
-      dx = xmax - xmin;
-      dy = ymax - ymin;
-      dz = zmax - zmin;
-    }
-  }
-
-  void read_test_points(filesystem::path pathname, PointList &points) {
-    const filesystem::path test_data_dir(TEST_DATA_DIR);
-    const auto data_dir(test_data_dir / "hammersley/");
-    const auto full_path(data_dir / pathname);
-    points.clear();
-    ifstream inf(full_path);
-    if (!inf) {
-      ostringstream msg;
-      msg << "Could not open " << pathname << " for reading." << endl;
-      FAIL(msg.str());
-    }
-    float x, y, z;
-    while (inf >> x >> y >> z) {
-      points.push_back({x, y, z});
-    }
-    inf.close();
-  }
-
-  std::unique_ptr<TCAxisAlignerEigen> new_aligner() {
-    PointList sphere;
-    float atom_scale = 1.0;
-
-    // Assume we will be run in a location fixed relative to
-    // the data files.
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, false);
-  }
-
-  std::unique_ptr<TCAxisAlignerEigen> new_aligner_ac_only() {
-    PointList sphere;
-    float atom_scale = 1.0;
-    read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
-    return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, true);
-  }
-
-  mol::Atom atom(string symbol, float x, float y, float z) const {
-    const unsigned char atomic_num(mol::get_atomic_num(symbol));
-    return {{atomic_num, {x, y, z}}};
-  } // namespace shape_eigen
-
-  void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) const {
-    // Coordinates taken from first cox2_3d conformer.
-    mol::AtomVector atoms{
-        atom("C", 27.7051, 22.0403, 17.0243),
-        atom("N", 26.4399, 22.0976, 16.4318),
-        atom("C", 25.5381, 21.4424, 17.2831),
-        atom("C", 26.2525, 20.9753, 18.3748),
-        atom("C", 27.5943, 21.3608, 18.2218),
-        atom("C", 24.0821, 21.3670, 17.1082),
-        atom("C", 26.1324, 22.6824, 15.1634),
-        atom("C", 23.4105, 22.2668, 16.2675),
-        atom("C", 22.0220, 22.2007, 16.1197),
-        atom("C", 21.2976, 21.2409, 16.8307),
-        atom("C", 21.9509, 20.3402, 17.6750),
-        atom("C", 23.3399, 20.4115, 17.8175),
-        atom("C", 26.3695, 24.0457, 14.9358),
-        atom("C", 26.0627, 24.6119, 13.6959),
-        atom("C", 25.5236, 23.8179, 12.6910),
-        atom("C", 25.2821, 22.4660, 12.9010),
-        atom("C", 25.5848, 21.8942, 14.1391),
-        atom("F", 25.2311, 24.3643, 11.5034),
-        atom("C", 28.9655, 22.5443, 16.4025),
-        atom("S", 19.5328, 21.1457, 16.6315),
-        atom("O", 19.0413, 22.4851, 16.3229),
-        atom("O", 18.9873, 20.4577, 17.7975),
-        atom("C", 19.3258, 20.1152, 15.2035),
-        atom("H", 25.8309, 20.4354, 19.2156),
-        atom("H", 28.4100, 21.1477, 18.9041),
-        atom("H", 23.9630, 23.0298, 15.7210),
-        atom("H", 21.5209, 22.9035, 15.4575),
-        atom("H", 21.3956, 19.5863, 18.2287),
-        atom("H", 23.8404, 19.7079, 18.4815),
-        atom("H", 26.7480, 24.6961, 15.7203),
-        atom("H", 26.2341, 25.6696, 13.5167),
-        atom("H", 24.8658, 21.8592, 12.1019),
-        atom("H", 25.4187, 20.8273, 14.2701),
-        atom("H", 29.8338, 22.0387, 16.8401),
-        atom("H", 29.0870, 23.6157, 16.5858),
-        atom("H", 28.9947, 22.3510, 15.3261),
-        atom("H", 18.2555, 20.0118, 15.0126),
-        atom("H", 19.7633, 19.1356, 15.4046),
-        atom("H", 19.8115, 20.5898, 14.3489),
-    };
-    mol = mol::Mol({.atoms = atoms});
-    num_heavies = 23;
-  }
-
-  void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
-    mol::Mol mol;
-
-    create_sample_mol(mol, num_heavies);
-    // Take care to deep-copy all of the atom pointers.
-    atoms.clear();
-    const mol::AtomVector &src(mol.atoms());
-    for (const auto src_atom : src) {
-      atoms.push_back(src_atom);
-    }
-  }
-
-  bool coords_match(const mol::AtomVector &atoms, const PointList &points,
-                    unsigned int count) {
-    // cout << "coords_match? " << endl
-    //      << "  # atoms:    " << atoms.size() << endl
-    //      << "  # points:   " << points.size() << endl
-    //      << "  # to check: " << count << endl;
-    if ((atoms.size() >= count) && (points.size() >= count)) {
-      for (int i = count - 1; i >= 0; --i) {
-        const mol::Atom &atom(atoms[i]);
-        const Point &p(points[i]);
-        const mol::Position &pos(atom.pos());
-        if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
-          return false;
-        }
-      }
-      return true;
-    }
-    return false;
-  }
-
-  void get_pointlist_info(const PointList &points, float &xmid, float &ymid,
-                          float &zmid, float &width, float &height,
-                          float &depth) {
-    xmid = ymid = zmid = width = height = depth = 0.0;
-    if (points.size()) {
-      float xmin, ymin, zmin, xmax, ymax, zmax;
-      float xsum = 0, ysum = 0, zsum = 0;
-      bool first = true;
-      for (const auto &point : points) {
-        const float x(point[0]), y(point[1]), z(point[2]);
-        xsum += x;
-        ysum += y;
-        zsum += z;
-
-        if (first) {
-          xmin = xmax = x;
-          ymin = ymax = y;
-          zmin = zmax = z;
-          first = false;
-        } else {
-          xmin = min(xmin, x);
-          xmax = max(xmax, x);
-          ymin = min(ymin, y);
-          ymax = max(ymax, y);
-          zmin = min(zmin, z);
-          zmax = max(zmax, z);
-        }
-      }
-
-      xmid = xsum / points.size();
-      ymid = ysum / points.size();
-      zmid = zsum / points.size();
-      width = xmax - xmin;
-      height = ymax - ymin;
-      depth = zmax - zmin;
-    }
-  }
-
-  bool is_mean_centered(const PointList &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
-    return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
-  }
-
-  bool has_nonincreasing_extents(const PointList &points) {
-    float xmid, ymid, zmid, w, h, d;
-    get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
-    bool result = ((w >= h) && (h >= d) && (d > 0));
-    return result;
-  }
-
-  float find_max_radius(const PointList &points) {
-    float result = 0.0;
+void get_point_means(const PointList &points, float &x, float &y, float &z) {
+  x = y = z = 0.0;
+  if (points.size()) {
+    float xsum = 0, ysum = 0, zsum = 0;
     for (const auto &point : points) {
-      result = max(result, point.at(3));
+      xsum += point[0];
+      ysum += point[1];
+      zsum += point[2];
     }
-    return result;
+    x = xsum / points.size();
+    y = ysum / points.size();
+    z = zsum / points.size();
   }
+}
 
-  bool is_non_null_transform(Transform &atom) { return !atom.isZero(); }
-};
+// Find the extent of set of points, along each axis.
+void get_point_extents(const PointList &points, float &dx, float &dy,
+                       float &dz) {
+  dx = dy = dz = 0.0;
+  if (points.size()) {
+    float xmin = 0, ymin = 0, zmin = 0, xmax = 0, ymax = 0, zmax = 0;
+    bool first = true;
+    for (const auto &point : points) {
+      if (first) {
+        xmin = xmax = point[0];
+        ymin = ymax = point[1];
+        zmin = zmax = point[2];
+        first = false;
+      } else {
+        xmin = min(xmin, point[0]);
+        xmax = max(xmax, point[0]);
+        ymin = min(ymin, point[1]);
+        ymax = max(ymax, point[1]);
+        zmin = min(zmin, point[2]);
+        zmax = max(zmax, point[2]);
+      }
+    }
+    dx = xmax - xmin;
+    dy = ymax - ymin;
+    dz = zmax - zmin;
+  }
+}
+
+void read_test_points(filesystem::path pathname, PointList &points) {
+  const filesystem::path test_data_dir(TEST_DATA_DIR);
+  const auto data_dir(test_data_dir / "hammersley/");
+  const auto full_path(data_dir / pathname);
+  points.clear();
+  ifstream inf(full_path);
+  if (!inf) {
+    ostringstream msg;
+    msg << "Could not open " << pathname << " for reading." << endl;
+    FAIL(msg.str());
+  }
+  float x, y, z;
+  while (inf >> x >> y >> z) {
+    points.push_back({x, y, z});
+  }
+  inf.close();
+}
+
+std::unique_ptr<TCAxisAlignerEigen> new_aligner() {
+  PointList sphere;
+  float atom_scale = 1.0;
+
+  // Assume we will be run in a location fixed relative to
+  // the data files.
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, false);
+}
+
+std::unique_ptr<TCAxisAlignerEigen> new_aligner_ac_only() {
+  PointList sphere;
+  float atom_scale = 1.0;
+  read_test_points("hamm_spheroid_10k_11rad.txt", sphere);
+  return std::make_unique<TCAxisAlignerEigen>(sphere, atom_scale, true);
+}
+
+mol::Atom atom(string symbol, float x, float y, float z) {
+  const unsigned char atomic_num(mol::get_atomic_num(symbol));
+  return {{atomic_num, {x, y, z}}};
+} // namespace shape_eigen
+
+void create_sample_mol(mol::Mol &mol, unsigned int &num_heavies) {
+  // Coordinates taken from first cox2_3d conformer.
+  mol::AtomVector atoms{
+      atom("C", 27.7051, 22.0403, 17.0243),
+      atom("N", 26.4399, 22.0976, 16.4318),
+      atom("C", 25.5381, 21.4424, 17.2831),
+      atom("C", 26.2525, 20.9753, 18.3748),
+      atom("C", 27.5943, 21.3608, 18.2218),
+      atom("C", 24.0821, 21.3670, 17.1082),
+      atom("C", 26.1324, 22.6824, 15.1634),
+      atom("C", 23.4105, 22.2668, 16.2675),
+      atom("C", 22.0220, 22.2007, 16.1197),
+      atom("C", 21.2976, 21.2409, 16.8307),
+      atom("C", 21.9509, 20.3402, 17.6750),
+      atom("C", 23.3399, 20.4115, 17.8175),
+      atom("C", 26.3695, 24.0457, 14.9358),
+      atom("C", 26.0627, 24.6119, 13.6959),
+      atom("C", 25.5236, 23.8179, 12.6910),
+      atom("C", 25.2821, 22.4660, 12.9010),
+      atom("C", 25.5848, 21.8942, 14.1391),
+      atom("F", 25.2311, 24.3643, 11.5034),
+      atom("C", 28.9655, 22.5443, 16.4025),
+      atom("S", 19.5328, 21.1457, 16.6315),
+      atom("O", 19.0413, 22.4851, 16.3229),
+      atom("O", 18.9873, 20.4577, 17.7975),
+      atom("C", 19.3258, 20.1152, 15.2035),
+      atom("H", 25.8309, 20.4354, 19.2156),
+      atom("H", 28.4100, 21.1477, 18.9041),
+      atom("H", 23.9630, 23.0298, 15.7210),
+      atom("H", 21.5209, 22.9035, 15.4575),
+      atom("H", 21.3956, 19.5863, 18.2287),
+      atom("H", 23.8404, 19.7079, 18.4815),
+      atom("H", 26.7480, 24.6961, 15.7203),
+      atom("H", 26.2341, 25.6696, 13.5167),
+      atom("H", 24.8658, 21.8592, 12.1019),
+      atom("H", 25.4187, 20.8273, 14.2701),
+      atom("H", 29.8338, 22.0387, 16.8401),
+      atom("H", 29.0870, 23.6157, 16.5858),
+      atom("H", 28.9947, 22.3510, 15.3261),
+      atom("H", 18.2555, 20.0118, 15.0126),
+      atom("H", 19.7633, 19.1356, 15.4046),
+      atom("H", 19.8115, 20.5898, 14.3489),
+  };
+  mol = mol::Mol({.atoms = atoms});
+  num_heavies = 23;
+}
+
+void create_sample_atoms(mol::AtomVector &atoms, unsigned int &num_heavies) {
+  mol::Mol mol;
+
+  create_sample_mol(mol, num_heavies);
+  // Take care to deep-copy all of the atom pointers.
+  atoms.clear();
+  const mol::AtomVector &src(mol.atoms());
+  for (const auto src_atom : src) {
+    atoms.push_back(src_atom);
+  }
+}
+
+bool coords_match(const mol::AtomVector &atoms, const PointList &points,
+                  unsigned int count) {
+  // cout << "coords_match? " << endl
+  //      << "  # atoms:    " << atoms.size() << endl
+  //      << "  # points:   " << points.size() << endl
+  //      << "  # to check: " << count << endl;
+  if ((atoms.size() >= count) && (points.size() >= count)) {
+    for (int i = count - 1; i >= 0; --i) {
+      const mol::Atom &atom(atoms[i]);
+      const Point &p(points[i]);
+      const mol::Position &pos(atom.pos());
+      if ((pos.x() != p[0]) || (pos.y() != p[1]) || (pos.z() != p[2])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+void get_pointlist_info(const PointList &points, float &xmid, float &ymid,
+                        float &zmid, float &width, float &height,
+                        float &depth) {
+  xmid = ymid = zmid = width = height = depth = 0.0;
+  if (points.size()) {
+    float xmin, ymin, zmin, xmax, ymax, zmax;
+    float xsum = 0, ysum = 0, zsum = 0;
+    bool first = true;
+    for (const auto &point : points) {
+      const float x(point[0]), y(point[1]), z(point[2]);
+      xsum += x;
+      ysum += y;
+      zsum += z;
+
+      if (first) {
+        xmin = xmax = x;
+        ymin = ymax = y;
+        zmin = zmax = z;
+        first = false;
+      } else {
+        xmin = min(xmin, x);
+        xmax = max(xmax, x);
+        ymin = min(ymin, y);
+        ymax = max(ymax, y);
+        zmin = min(zmin, z);
+        zmax = max(zmax, z);
+      }
+    }
+
+    xmid = xsum / points.size();
+    ymid = ysum / points.size();
+    zmid = zsum / points.size();
+    width = xmax - xmin;
+    height = ymax - ymin;
+    depth = zmax - zmin;
+  }
+}
+
+bool is_mean_centered(const PointList &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  auto matcher = Catch::Matchers::WithinAbs(0.0, 0.0001);
+  return matcher.match(xmid) && matcher.match(ymid) && matcher.match(zmid);
+}
+
+bool has_nonincreasing_extents(const PointList &points) {
+  float xmid, ymid, zmid, w, h, d;
+  get_pointlist_info(points, xmid, ymid, zmid, w, h, d);
+  bool result = ((w >= h) && (h >= d) && (d > 0));
+  return result;
+}
+
+float find_max_radius(const PointList &points) {
+  float result = 0.0;
+  for (const auto &point : points) {
+    result = max(result, point.at(3));
+  }
+  return result;
+}
+
+bool is_non_null_transform(Transform &atom) { return !atom.isZero(); }
 
 TEST_CASE("mesaac::shape::AxisAlignerEigen - Find axis-align transform",
           "[mesaac]") {
-  TestFixture fixture;
-  std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
+  std::unique_ptr<TCAxisAlignerEigen> aligner(new_aligner());
   mol::AtomVector atoms;
   PointList points;
   PointList cloud;
   unsigned int num_heavies;
 
-  fixture.create_sample_atoms(atoms, num_heavies);
+  create_sample_atoms(atoms, num_heavies);
   aligner->tc_get_atom_points(atoms, points, false);
   aligner->tc_mean_center_points(points);
   aligner->tc_get_mean_centered_cloud(points, cloud);
@@ -307,17 +304,16 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen - Find axis-align transform",
   // Not sure how to test this.  Just confirm it's a 3x3 matrix
   // with non-empty cells?
   Transform transform = Transform::Zero();
-  REQUIRE(!fixture.is_non_null_transform(transform));
+  REQUIRE(!is_non_null_transform(transform));
 
   aligner->tc_find_axis_align_transform(cloud, transform);
-  REQUIRE(fixture.is_non_null_transform(transform));
+  REQUIRE(is_non_null_transform(transform));
 }
 
 TEST_CASE(
     "mesaac::shape::AxisAlignerEigen - Detect and fix mirrored-axis transforms",
     "[mesaac]") {
-  TestFixture fixture;
-  std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
+  std::unique_ptr<TCAxisAlignerEigen> aligner(new_aligner());
   Transform no_flip = Transform::Identity();
 
   // Ensure transform has no flipped axis.
@@ -337,8 +333,7 @@ TEST_CASE(
 }
 
 TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
-  TestFixture fixture;
-  std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
+  std::unique_ptr<TCAxisAlignerEigen> aligner(new_aligner());
   mol::AtomVector atoms;
   PointList points;
 
@@ -355,14 +350,14 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
   SECTION("Get atom coords from a vector of heavy atoms") {
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     REQUIRE(atoms.size() > num_heavies);
     REQUIRE(num_heavies > 0);
-    REQUIRE(fixture.coords_match(atoms, points, num_heavies));
+    REQUIRE(coords_match(atoms, points, num_heavies));
 
     aligner->tc_get_atom_points(atoms, points, true);
-    REQUIRE(fixture.coords_match(atoms, points, atoms.size()));
+    REQUIRE(coords_match(atoms, points, atoms.size()));
   }
 
   SECTION("Get the mean center of an empty list of points") {
@@ -379,7 +374,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     unsigned int num_heavies;
     Point center;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     aligner->tc_get_mean_center(points, center);
     REQUIRE(center.size() == (size_t)3);
@@ -402,15 +397,15 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 
     // TODO:  create a set of atoms w. known positions and
     // easily verified extents.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     REQUIRE(points.size() == (size_t)num_heavies);
     aligner->tc_mean_center_points(points);
     REQUIRE(points.size() == (size_t)num_heavies);
-    REQUIRE(fixture.is_mean_centered(points));
+    REQUIRE(is_mean_centered(points));
 
     float xmid, ymid, zmid, width, height, depth;
-    fixture.get_pointlist_info(points, xmid, ymid, zmid, width, height, depth);
+    get_pointlist_info(points, xmid, ymid, zmid, width, height, depth);
     REQUIRE_THAT(9.9782, Catch::Matchers::WithinAbs(width, 0.00001));
     REQUIRE_THAT(4.4967, Catch::Matchers::WithinAbs(height, 0.00001));
     REQUIRE_THAT(6.8714, Catch::Matchers::WithinAbs(depth, 0.00001));
@@ -428,7 +423,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     PointList cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
     REQUIRE(points.size() > 0);
     REQUIRE(points.size() == (size_t)num_heavies);
@@ -438,17 +433,15 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE(cloud.size() > 0);
 
     float xmid, ymid, zmid, pwidth, pheight, pdepth;
-    fixture.get_pointlist_info(points, xmid, ymid, zmid, pwidth, pheight,
-                               pdepth);
-    REQUIRE(fixture.is_mean_centered(points));
+    get_pointlist_info(points, xmid, ymid, zmid, pwidth, pheight, pdepth);
+    REQUIRE(is_mean_centered(points));
     REQUIRE_THAT(9.9782, Catch::Matchers::WithinAbs(pwidth, 0.00001));
     REQUIRE_THAT(4.4967, Catch::Matchers::WithinAbs(pheight, 0.00001));
     REQUIRE_THAT(6.8714, Catch::Matchers::WithinAbs(pdepth, 0.00001));
 
     float cwidth, cheight, cdepth;
-    fixture.get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight,
-                               cdepth);
-    float dmax = 2.0 * fixture.find_max_radius(points);
+    get_pointlist_info(cloud, xmid, ymid, zmid, cwidth, cheight, cdepth);
+    float dmax = 2.0 * find_max_radius(points);
     // Bench-check:  max radius should be 1.8, for sulfur.
     REQUIRE(dmax == 3.60f);
 
@@ -467,7 +460,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
   //   PointList cloud;
   //   unsigned int num_heavies;
 
-  //   fixture.create_sample_atoms(atoms, num_heavies);
+  //   create_sample_atoms(atoms, num_heavies);
   //   aligner->tc_get_atom_points(atoms, points, false);
   //   aligner->tc_mean_center_points(points);
   //   aligner->tc_get_mean_centered_cloud(points, cloud);
@@ -475,10 +468,10 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
   //   // Not sure how to test this.  Just confirm it's a 3x3 matrix
   //   // with non-empty cells?
   //   Transform transform = Transform::Zero();
-  //   REQUIRE(!fixture.is_non_null_transform(transform));
+  //   REQUIRE(!is_non_null_transform(transform));
 
   //   aligner->tc_find_axis_align_transform(cloud, transform);
-  //   REQUIRE(fixture.is_non_null_transform(transform));
+  //   REQUIRE(is_non_null_transform(transform));
   // }
 
   SECTION("Untranslate points") {
@@ -515,16 +508,16 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE_THROWS_AS(aligner->tc_find_axis_align_transform(cloud, transform),
                       invalid_argument);
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
+    REQUIRE(!is_mean_centered(points));
     aligner->tc_mean_center_points(points);
-    REQUIRE(fixture.is_mean_centered(points));
+    REQUIRE(is_mean_centered(points));
     aligner->tc_get_mean_centered_cloud(points, cloud);
 
-    REQUIRE(!fixture.is_non_null_transform(transform));
+    REQUIRE(!is_non_null_transform(transform));
     aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
+    REQUIRE(is_non_null_transform(transform));
 
     // Verify no crash on an empty point list.
     points.clear();
@@ -532,13 +525,13 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE(points.empty());
 
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     aligner->tc_transform_points(points, transform);
     REQUIRE(points.size() == (size_t)num_heavies);
 
     // Transform should merely rotate the points -- no mean-centering.
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Update atom coords") {
@@ -547,7 +540,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 
     // Ensure correct copying of transformed point coords to
     // corresponding atom coords.
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
 
     // Point and atom lists of different size?  This should fail.
     aligner->tc_get_atom_points(atoms, points, false);
@@ -580,16 +573,16 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     PointList points, cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
+    create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!is_mean_centered(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(atoms);
     aligner->tc_get_atom_points(atoms, points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(is_mean_centered(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Align mol to axes") {
@@ -602,16 +595,16 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     PointList points, cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!is_mean_centered(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     // TODO:  Check that the hydrogens are also transformed.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(is_mean_centered(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Point cloud alignment") {
@@ -624,18 +617,18 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     PointList points, cloud;
     unsigned int num_heavies;
 
-    fixture.create_sample_mol(mol, num_heavies);
+    create_sample_mol(mol, num_heavies);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(!fixture.is_mean_centered(points));
-    REQUIRE(!fixture.has_nonincreasing_extents(points));
+    REQUIRE(!is_mean_centered(points));
+    REQUIRE(!has_nonincreasing_extents(points));
 
     // TODO:  Check that the hydrogens are also transformed.
     // TODO:  Check that align_to_axes with atom-centers-only produces
     // different results than without atom-centers-only.
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), points, false);
-    REQUIRE(fixture.is_mean_centered(points));
-    REQUIRE(fixture.has_nonincreasing_extents(points));
+    REQUIRE(is_mean_centered(points));
+    REQUIRE(has_nonincreasing_extents(points));
   }
 
   SECTION("Align hydrogens") {
@@ -644,20 +637,19 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     // the X axis.
     float x, y, z, w, h, d;
 
-    mol::Mol mol(
-        {.atoms = {
-             fixture.atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
-             fixture.atom("H", 0.0, 0.0, 1.0),
-             fixture.atom("C", 0.0, 0.0, 2.0),
-             fixture.atom("H", 0.0, 0.0, 3.0),
-             fixture.atom("C", 0.0, 0.0, 4.0),
-             fixture.atom("H", 0.0, 0.0, 5.0),
-             fixture.atom("C", 0.0, 0.0, 6.0),
-             fixture.atom("H", 0.0, 0.0, 7.0),
-         }});
+    mol::Mol mol({.atoms = {
+                      atom("C", 0.0, 0.0, 0.0), // Stay inside the point cloud
+                      atom("H", 0.0, 0.0, 1.0),
+                      atom("C", 0.0, 0.0, 2.0),
+                      atom("H", 0.0, 0.0, 3.0),
+                      atom("C", 0.0, 0.0, 4.0),
+                      atom("H", 0.0, 0.0, 5.0),
+                      atom("C", 0.0, 0.0, 6.0),
+                      atom("H", 0.0, 0.0, 7.0),
+                  }});
 
     aligner->tc_get_atom_points(mol.atoms(), points, true);
-    fixture.get_pointlist_info(points, x, y, z, w, h, d);
+    get_pointlist_info(points, x, y, z, w, h, d);
     REQUIRE(w == 0.0f);
     REQUIRE(h == 0.0f);
     REQUIRE(d == 7.0f);
@@ -665,7 +657,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     aligner->align_to_axes(mol);
     aligner->tc_get_atom_points(mol.atoms(), points, true);
 
-    fixture.get_pointlist_info(points, x, y, z, w, h, d);
+    get_pointlist_info(points, x, y, z, w, h, d);
 
     // The slope from point to point should be consistent.
     const float dx_dy = w / h;
@@ -718,13 +710,12 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 }
 
 namespace {
-int benchmark_align_to_axes(const TestFixture &fixture,
-                            std::shared_ptr<TCAxisAlignerEigen> aligner) {
+int benchmark_align_to_axes(std::shared_ptr<TCAxisAlignerEigen> aligner) {
   mol::Mol mol;
   PointList points, cloud;
   unsigned int num_heavies;
 
-  fixture.create_sample_mol(mol, num_heavies);
+  create_sample_mol(mol, num_heavies);
   aligner->tc_get_atom_points(mol.atoms(), points, false);
 
   // TODO:  Check that the hydrogens are also transformed.
@@ -737,23 +728,17 @@ int benchmark_align_to_axes(const TestFixture &fixture,
 
 TEST_CASE("mesaac::shape::AxisAlignerEigen Benchmarks",
           "[mesaac][mesaac_benchmark]") {
-  TestFixture fixture;
 
   BENCHMARK_ADVANCED("Point cloud alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
-    meter.measure([fixture, aligner] {
-      return benchmark_align_to_axes(fixture, aligner);
-    });
+    std::shared_ptr<TCAxisAlignerEigen> aligner(new_aligner());
+    meter.measure([aligner] { return benchmark_align_to_axes(aligner); });
   };
 
   BENCHMARK_ADVANCED("Atom center alignment")(
       Catch::Benchmark::Chronometer meter) {
-    std::shared_ptr<TCAxisAlignerEigen> ac_aligner(
-        fixture.new_aligner_ac_only());
-    meter.measure([fixture, ac_aligner] {
-      return benchmark_align_to_axes(fixture, ac_aligner);
-    });
+    std::shared_ptr<TCAxisAlignerEigen> ac_aligner(new_aligner_ac_only());
+    meter.measure([ac_aligner] { return benchmark_align_to_axes(ac_aligner); });
   };
 }
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
@@ -456,24 +456,6 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE(ddepth <= dmax);
   }
 
-  // SECTION("Find axis-align transform") {
-  //   PointList cloud;
-  //   unsigned int num_heavies;
-
-  //   create_sample_atoms(atoms, num_heavies);
-  //   aligner->tc_get_atom_points(atoms, points, false);
-  //   aligner->tc_mean_center_points(points);
-  //   aligner->tc_get_mean_centered_cloud(points, cloud);
-
-  //   // Not sure how to test this.  Just confirm it's a 3x3 matrix
-  //   // with non-empty cells?
-  //   Transform transform = Transform::Zero();
-  //   REQUIRE(!is_non_null_transform(transform));
-
-  //   aligner->tc_find_axis_align_transform(cloud, transform);
-  //   REQUIRE(is_non_null_transform(transform));
-  // }
-
   SECTION("Untranslate points") {
     Point offset{1.0, 2.0, 3.0};
 

--- a/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
@@ -9,6 +9,10 @@
 #include <filesystem>
 #include <fstream>
 
+// Needed in order to call .determinant() when compiling with Release build
+// type.
+#include <Eigen/Dense>
+
 #include "mesaac_mol/element_info.hpp"
 #include "mesaac_shape/axis_aligner_eigen.hpp"
 
@@ -39,6 +43,8 @@ public:
   void tc_get_mean_centered_cloud(const PointList &centers, PointList &cloud) {
     get_mean_centered_cloud(centers, cloud);
   }
+
+  void tc_unmirror_axes(Transform &t) { unmirror_axes(t); }
 
   void tc_find_axis_align_transform(const PointList &cloud, Transform &t) {
     find_axis_align_transform(cloud, t);
@@ -284,7 +290,8 @@ struct TestFixture {
   bool is_non_null_transform(Transform &atom) { return !atom.isZero(); }
 };
 
-TEST_CASE("mesaac::shape::AxisAlignerEigen - Find axis-align transform", "[mesaac]") {
+TEST_CASE("mesaac::shape::AxisAlignerEigen - Find axis-align transform",
+          "[mesaac]") {
   TestFixture fixture;
   std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
   mol::AtomVector atoms;
@@ -306,6 +313,28 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen - Find axis-align transform", "[mesaa
   REQUIRE(fixture.is_non_null_transform(transform));
 }
 
+TEST_CASE(
+    "mesaac::shape::AxisAlignerEigen - Detect and fix mirrored-axis transforms",
+    "[mesaac]") {
+  TestFixture fixture;
+  std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
+  Transform no_flip = Transform::Identity();
+
+  // Ensure transform has no flipped axis.
+  REQUIRE(no_flip.determinant() > 0);
+  // Ensure unmirroring does not modify the transform.
+  aligner->tc_unmirror_axes(no_flip);
+  REQUIRE(no_flip == Transform::Identity());
+
+  Transform y_flip = Transform::Identity();
+  y_flip(1, 1) = -1.0;
+
+  // Ensure transform has a flipped axis.
+  REQUIRE(y_flip.determinant() < 0);
+  // WEAK: Ensure unmirroring results in no flipped axes.
+  aligner->tc_unmirror_axes(y_flip);
+  REQUIRE(y_flip.determinant() > 0);
+}
 
 TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
   TestFixture fixture;

--- a/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
+++ b/tests/src/lib/mesaac_shape/test_axis_aligner_eigen.cpp
@@ -284,6 +284,29 @@ struct TestFixture {
   bool is_non_null_transform(Transform &atom) { return !atom.isZero(); }
 };
 
+TEST_CASE("mesaac::shape::AxisAlignerEigen - Find axis-align transform", "[mesaac]") {
+  TestFixture fixture;
+  std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
+  mol::AtomVector atoms;
+  PointList points;
+  PointList cloud;
+  unsigned int num_heavies;
+
+  fixture.create_sample_atoms(atoms, num_heavies);
+  aligner->tc_get_atom_points(atoms, points, false);
+  aligner->tc_mean_center_points(points);
+  aligner->tc_get_mean_centered_cloud(points, cloud);
+
+  // Not sure how to test this.  Just confirm it's a 3x3 matrix
+  // with non-empty cells?
+  Transform transform = Transform::Zero();
+  REQUIRE(!fixture.is_non_null_transform(transform));
+
+  aligner->tc_find_axis_align_transform(cloud, transform);
+  REQUIRE(fixture.is_non_null_transform(transform));
+}
+
+
 TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
   TestFixture fixture;
   std::unique_ptr<TCAxisAlignerEigen> aligner(fixture.new_aligner());
@@ -411,23 +434,23 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     REQUIRE(ddepth <= dmax);
   }
 
-  SECTION("Find axis-align transform") {
-    PointList cloud;
-    unsigned int num_heavies;
+  // SECTION("Find axis-align transform") {
+  //   PointList cloud;
+  //   unsigned int num_heavies;
 
-    fixture.create_sample_atoms(atoms, num_heavies);
-    aligner->tc_get_atom_points(atoms, points, false);
-    aligner->tc_mean_center_points(points);
-    aligner->tc_get_mean_centered_cloud(points, cloud);
+  //   fixture.create_sample_atoms(atoms, num_heavies);
+  //   aligner->tc_get_atom_points(atoms, points, false);
+  //   aligner->tc_mean_center_points(points);
+  //   aligner->tc_get_mean_centered_cloud(points, cloud);
 
-    // Not sure how to test this.  Just confirm it's a 3x3 matrix
-    // with non-empty cells?
-    Transform transform = Transform::Zero();
-    REQUIRE(!fixture.is_non_null_transform(transform));
+  //   // Not sure how to test this.  Just confirm it's a 3x3 matrix
+  //   // with non-empty cells?
+  //   Transform transform = Transform::Zero();
+  //   REQUIRE(!fixture.is_non_null_transform(transform));
 
-    aligner->tc_find_axis_align_transform(cloud, transform);
-    REQUIRE(fixture.is_non_null_transform(transform));
-  }
+  //   aligner->tc_find_axis_align_transform(cloud, transform);
+  //   REQUIRE(fixture.is_non_null_transform(transform));
+  // }
 
   SECTION("Untranslate points") {
     Point offset{1.0, 2.0, 3.0};
@@ -441,7 +464,7 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
     unsigned int i;
     const unsigned int i_max = 10;
     for (i = 0; i != i_max; i++) {
-      points.push_back({i + 1.0f, i + 2.0f, i + 3.0f});
+      points.push_back({i + offset[0], i + offset[1], i + offset[2]});
     }
 
     aligner->tc_untranslate_points(points, offset);
@@ -465,7 +488,9 @@ TEST_CASE("mesaac::shape::AxisAlignerEigen", "[mesaac]") {
 
     fixture.create_sample_atoms(atoms, num_heavies);
     aligner->tc_get_atom_points(atoms, points, false);
+    REQUIRE(!fixture.is_mean_centered(points));
     aligner->tc_mean_center_points(points);
+    REQUIRE(fixture.is_mean_centered(points));
     aligner->tc_get_mean_centered_cloud(points, cloud);
 
     REQUIRE(!fixture.is_non_null_transform(transform));


### PR DESCRIPTION
I'm lousy at staying in scope...

This PR addresses issue #5.

Main changes:
* Run `ctest` benchmarks with Release-mode code.
* Add a benchmark for `align_monte`.
* Remove OpenMP code.
* Use `std::future` to perform multiple alignments concurrently.
  -  Experiments showed no real performance gain, and quite a bit more complexity, from using thread pools.
* Document steps for using `perf` to measure performance on Ubuntu.

With the changes above, release-build performance on a Ryzen 5 system running Ubuntu was about 5x slower than on an M1 Pro MacBook Pro.  Profiling showed most of the time was spent in `svd` routines.  For this reason, this PR goes beyond the scope of issue #5 in the following ways:

* Use `mesaac::shape::AxisAlignerEigen` instead of `mesaac::shape::AxisAligner`.
* Improve detection and correction of mirrored axes in `AxisAlignerEigen`.
* Clean up unit testing code for both `AxisAligner` and `AxisAlignerEigen`.